### PR TITLE
Avoid using IsCompletedSuccessfully extension method in FileSystemWat…

### DIFF
--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
@@ -595,9 +595,15 @@ namespace System.IO
             }
 
             // Return the results.
+#if MONO
+            return tcs.Task.Status == TaskStatus.RanToCompletion ?
+                tcs.Task.Result :
+                WaitForChangedResult.TimedOutResult;
+#else
             return tcs.Task.IsCompletedSuccessfully ?
                 tcs.Task.Result :
                 WaitForChangedResult.TimedOutResult;
+#endif
         }
 
         /// <devdoc>


### PR DESCRIPTION
…cher under Mono.

The extension method does not exist under Mono and is not easy to import from CoreFX (it's defined in System.Runtime.cs)