### PR TITLE
[System.Data] Fix ambiguous reference to ValueType

### DIFF
--- a/src/System.Data.DataSetExtensions/src/System/Data/DataRowComparer.cs
+++ b/src/System.Data.DataSetExtensions/src/System/Data/DataRowComparer.cs
@@ -206,7 +206,7 @@ namespace System.Data
                 }
                 else
                 {
-                    ValueType vt = value as ValueType;
+                    var vt = value as System.ValueType;
 
                     // have to unbox value types.
                     if (vt != null)


### PR DESCRIPTION
Mono already has System.Data.ValueType 