### PR TITLE
Extend SSL System.Data workaround for linux with disabled BTLS

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -342,7 +342,7 @@ namespace System.Data.SqlClient.SNI
         public override void DisableSsl()
         {
 #if !MONO || MONO_FEATURE_BTLS || MONO_FEATURE_APPLETLS
-            // Temp workaround - SSLStream.Dispose causes an expected behavior with legacy ssl implementation
+            // SSLStream.Dispose causes an expected behavior with legacy ssl implementation
             _sslStream.Dispose();
 #endif
             _sslStream = null;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -342,7 +342,7 @@ namespace System.Data.SqlClient.SNI
         public override void DisableSsl()
         {
 #if !MONO || MONO_FEATURE_BTLS || MONO_FEATURE_APPLETLS
-            // SSLStream.Dispose causes an expected behavior with legacy ssl implementation
+            // SSLStream.Dispose causes an unexpected behavior with legacy ssl implementation
             _sslStream.Dispose();
 #endif
             _sslStream = null;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -341,11 +341,10 @@ namespace System.Data.SqlClient.SNI
         /// </summary>
         public override void DisableSsl()
         {
-#if MONO
-            // Temp workaround - SSLStream.Dispose causes an expected behavior in mono for windows
-            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
-#endif
+#if !MONO || MONO_FEATURE_BTLS || MONO_FEATURE_APPLETLS
+            // Temp workaround - SSLStream.Dispose causes an expected behavior with legacy ssl implementation
             _sslStream.Dispose();
+#endif
             _sslStream = null;
             _sslOverTdsStream.Dispose();
             _sslOverTdsStream = null;


### PR DESCRIPTION
Part of the fix for https://github.com/mono/mono/issues/6350