### PR TITLE
Fix appletls check, hide some TypeForwarders

### DIFF
--- a/src/Common/src/CoreLib/System/Threading/Tasks/TaskCanceledException.cs
+++ b/src/Common/src/CoreLib/System/Threading/Tasks/TaskCanceledException.cs
@@ -20,7 +20,9 @@ namespace System.Threading.Tasks
     /// Represents an exception used to communicate task cancellation.
     /// </summary>
     [Serializable]
+#if !MONO
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
     public class TaskCanceledException : OperationCanceledException
     {
         [NonSerialized]

--- a/src/Common/src/CoreLib/System/Threading/Tasks/TaskSchedulerException.cs
+++ b/src/Common/src/CoreLib/System/Threading/Tasks/TaskSchedulerException.cs
@@ -21,7 +21,9 @@ namespace System.Threading.Tasks
     /// <see cref="T:System.Threading.Tasks.TaskScheduler"/>.
     /// </summary>
     [Serializable]
+#if !MONO
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
     public class TaskSchedulerException : Exception
     {
         /// <summary>

--- a/src/Common/src/CoreLib/System/Threading/Tasks/TaskToApm.cs
+++ b/src/Common/src/CoreLib/System/Threading/Tasks/TaskToApm.cs
@@ -16,7 +16,7 @@
 //         return TaskToApm.End<int>(asyncResult);
 //     }
 
-using System.Diagnostics;
+using System.Diagnostics.Private;
 
 namespace System.Threading.Tasks
 {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -392,7 +392,7 @@ namespace System.Data.SqlClient.SNI
         /// </summary>
         public override void DisableSsl()
         {
-#if !MONO || MONO_FEATURE_BTLS || MONO_FEATURE_APPLETLS
+#if !MONO || MONO_FEATURE_BTLS || ONLY_APPLETLS
             // SSLStream.Dispose causes an unexpected behavior with legacy ssl implementation
             _sslStream.Dispose();
 #endif

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/ProducerConsumerQueues.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/ProducerConsumerQueues.cs
@@ -31,6 +31,7 @@ using System.Collections.Concurrent;
 #endif
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Private;
 using System.Runtime.InteropServices;
 
 namespace System.Threading.Tasks


### PR DESCRIPTION
Needed for https://github.com/mono/mono/pull/6672
Also, fix AppleTLS check in SNITcpHandle.cs (as MONO_FEATURE_APPLETLS might be defined with Legacy TLS as a provider)