### PR TITLE
Revert "Disables failing test...

### DIFF
--- a/src/Microsoft.CSharp/tests/IntegerUnaryOperationTests.cs
+++ b/src/Microsoft.CSharp/tests/IntegerUnaryOperationTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
             }
         }
 
-        [Theory(Skip="https://github.com/mono/mono/issues/6721")]
+        [Theory]
         [MemberData(nameof(Int32TestNegations))]
         [MemberData(nameof(Int32TestUnaryPluses))]
         [MemberData(nameof(Int32TestOnesComplements))]


### PR DESCRIPTION
... tracked as https://github.com/mono/mono/issues/6721

This reverts commit c01df835c904b0c927a3dcc983c86fa86778b498.

It got fixed via https://github.com/mono/mono/pull/6753