### PR TITLE
[System.Text] Bring back mono-specific attributes to keep API the same

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompilationInfo.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompilationInfo.cs
@@ -4,6 +4,9 @@
 
 namespace System.Text.RegularExpressions
 {
+#if MONO
+    [System.Serializable]
+#endif
     public class RegexCompilationInfo
     {
         private string _pattern;


### PR DESCRIPTION
Needed for https://github.com/mono/mono/pull/7363