### PR TITLE
Hide TypeForwarders from mono (Collections)

### DIFF
--- a/src/Common/src/CoreLib/System/Collections/Generic/KeyNotFoundException.cs
+++ b/src/Common/src/CoreLib/System/Collections/Generic/KeyNotFoundException.cs
@@ -8,7 +8,9 @@ using System.Runtime.Serialization;
 namespace System.Collections.Generic
 {
     [Serializable]
+#if !MONO
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
     public class KeyNotFoundException : SystemException
     {
         public KeyNotFoundException()

--- a/src/Common/src/CoreLib/System/Collections/Generic/List.cs
+++ b/src/Common/src/CoreLib/System/Collections/Generic/List.cs
@@ -17,7 +17,9 @@ namespace System.Collections.Generic
     [DebuggerTypeProxy(typeof(ICollectionDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
     [Serializable]
+#if !MONO
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
     public class List<T> : IList<T>, System.Collections.IList, IReadOnlyList<T>
     {
         private const int DefaultCapacity = 4;

--- a/src/Common/src/CoreLib/System/Collections/ObjectModel/ReadOnlyCollection.cs
+++ b/src/Common/src/CoreLib/System/Collections/ObjectModel/ReadOnlyCollection.cs
@@ -10,7 +10,9 @@ namespace System.Collections.ObjectModel
     [Serializable]
     [DebuggerTypeProxy(typeof(ICollectionDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
+#if !MONO
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
     public class ReadOnlyCollection<T> : IList<T>, IList, IReadOnlyList<T>
     {
         private IList<T> list; // Do not rename (binary serialization)

--- a/src/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/System.Collections/src/System/Collections/BitArray.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Diagnostics.Private;
 
 namespace System.Collections
 {


### PR DESCRIPTION
Needed for https://github.com/mono/mono/pull/7478