### PR TITLE
hide TypeForwarders from mono (Collections)

### DIFF
--- a/src/Common/src/CoreLib/System/Collections/Generic/List.cs
+++ b/src/Common/src/CoreLib/System/Collections/Generic/List.cs
@@ -1177,6 +1177,9 @@ namespace System.Collections.Generic
             }
         }
 
+#if MONO
+        [System.Serializable]
+#endif
         public struct Enumerator : IEnumerator<T>, System.Collections.IEnumerator
         {
             private List<T> _list;

--- a/src/Common/src/CoreLib/System/Collections/ObjectModel/Collection.cs
+++ b/src/Common/src/CoreLib/System/Collections/ObjectModel/Collection.cs
@@ -10,7 +10,9 @@ namespace System.Collections.ObjectModel
     [Serializable]
     [DebuggerTypeProxy(typeof(ICollectionDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
+#if !MONO
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
     public class Collection<T> : IList<T>, IList, IReadOnlyList<T>
     {
         private IList<T> items; // Do not rename (binary serialization)

--- a/src/System.Runtime.Extensions/src/System/Collections/IHashCodeProvider.cs
+++ b/src/System.Runtime.Extensions/src/System/Collections/IHashCodeProvider.cs
@@ -9,7 +9,9 @@ namespace System.Collections
     /// GetHashCode() function on Objects, providing their own hash function.
     /// </summary>
     [Obsolete("Please use IEqualityComparer instead.")]
+#if !MONO
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
     public interface IHashCodeProvider
     {
         /// <summary>Returns a hash code for the given object.</summary>


### PR DESCRIPTION
Needed for https://github.com/mono/mono/pull/7478