### PR TITLE
Disable compiled Regex by default, but allow for it to be turned on.

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -1079,11 +1079,21 @@ namespace System.Text.RegularExpressions
             return newcached;
         }
 
+#if MONO
+	// This is here so we can debug this issue: https://github.com/mono/mono/pull/7982,
+	// once that is fixed, we can remove this.
+	
+	bool enableCompiled = Environment.GetEnvironmentVariable ("MONO_REGEX_COMPILED_ENABLE") != null;
+        protected bool UseOptionC()
+        {
+            return enableCompiled && (roptions & RegexOptions.Compiled) != 0;
+        }
+#else
         protected bool UseOptionC()
         {
             return (roptions & RegexOptions.Compiled) != 0;
         }
-
+#endif
         /*
          * True if the L option was set
          */

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -1081,13 +1081,21 @@ namespace System.Text.RegularExpressions
 
 #if MONO
 	// This is here so we can debug this issue: https://github.com/mono/mono/pull/7982,
-	// once that is fixed, we can remove this.
-	
-	bool enableCompiled = Environment.GetEnvironmentVariable ("MONO_REGEX_COMPILED_ENABLE") != null;
+	// once that is fixed, we can remove this.   Disabling it completely for mobile
+	// as we are not likely to debug the threading issue there.
+
+#if !MOBILE
+	static bool enableCompiled = Environment.GetEnvironmentVariable ("MONO_REGEX_COMPILED_ENABLE") != null;
+#endif
         protected bool UseOptionC()
         {
-            return enableCompiled && (roptions & RegexOptions.Compiled) != 0;
+#if MOBILE
+            return false
+#else
+	    return enableCompiled && (roptions & RegexOptions.Compiled) != 0;
         }
+#endif
+	
 #else
         protected bool UseOptionC()
         {

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -1079,29 +1079,21 @@ namespace System.Text.RegularExpressions
             return newcached;
         }
 
-#if MONO
-	// This is here so we can debug this issue: https://github.com/mono/mono/pull/7982,
-	// once that is fixed, we can remove this.   Disabling it completely for mobile
-	// as we are not likely to debug the threading issue there.
-
-#if !MOBILE
-	static bool enableCompiled = Environment.GetEnvironmentVariable ("MONO_REGEX_COMPILED_ENABLE") != null;
-#endif
         protected bool UseOptionC()
         {
 #if MOBILE
             return false
-#else
-	    return enableCompiled && (roptions & RegexOptions.Compiled) != 0;
-        }
+#elif MONO
+            // This is here so we can debug this issue: https://github.com/mono/mono/pull/7982,
+            // once that is fixed, we can remove this.   Disabling it completely for mobile
+            // as we are not likely to debug the threading issue there.
+            if (Environment.GetEnvironmentVariable ("MONO_REGEX_COMPILED_ENABLE") == null)
+                return false;
 #endif
-	
-#else
-        protected bool UseOptionC()
-        {
+
             return (roptions & RegexOptions.Compiled) != 0;
         }
-#endif
+
         /*
          * True if the L option was set
          */


### PR DESCRIPTION
This is so we can fix https://github.com/mono/mono/issues/7975 more easily.