### PR TITLE
Skip flaky-tests on mono, runtime.serialization fixes

### DIFF
--- a/src/Common/src/CoreLib/System/Text/StringBuilder.cs
+++ b/src/Common/src/CoreLib/System/Text/StringBuilder.cs
@@ -27,7 +27,9 @@ namespace System.Text
     // object unless specified otherwise.  This class may be used in conjunction with the String
     // class to carry out modifications upon strings.
     [Serializable]
+#if !MONO
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
     public sealed partial class StringBuilder : ISerializable
     {
         // A StringBuilder is internally represented as a linked list of blocks each of which holds

--- a/src/System.Collections/tests/BitArray/BitArray_CtorTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_CtorTests.cs
@@ -192,6 +192,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "Flaky test - OOM")]
         public static void Ctor_LargeIntArrayOverflowingBitArray_ThrowsArgumentException()
         {
             AssertExtensions.Throws<ArgumentException>("values", () => new BitArray(new int[int.MaxValue / BitsPerInt32 + 1 ]));
@@ -231,6 +232,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "Flaky test - OOM")]
         public static void Ctor_LargeByteArrayOverflowingBitArray_ThrowsArgumentException()
         {
             AssertExtensions.Throws<ArgumentException>("bytes", () => new BitArray(new byte[int.MaxValue / BitsPerByte + 1 ]));
@@ -250,6 +252,7 @@ namespace System.Collections.Tests
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "A bug in BitArray.Clone() caused an ArgumentExeption to be thrown in this case.")]
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "Flaky test - OOM")]
         public static void Clone_LongLength_Works()
         {
             BitArray bitArray = new BitArray(int.MaxValue - 30);

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlDataContract.cs
@@ -388,11 +388,9 @@ namespace System.Runtime.Serialization
             else
             {
                 object o = null;
-                if (type.FullName == "System.Xml.Linq.XElement")
+                if (type == typeof(System.Xml.Linq.XElement))
                 {
-                    var xnameType = type.Assembly.GetType("System.Xml.Linq.XName");
-                    var xname = xnameType.GetMethod("Get", new[] { typeof(string) }).Invoke(null, new object[] { "default" });
-                    o = Activator.CreateInstance(type.Assembly.GetType("System.Xml.Linq.XElement"), xname);
+                    o = new System.Xml.Linq.XElement("default");
                 }
                 else
                 {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlDataContract.cs
@@ -388,9 +388,11 @@ namespace System.Runtime.Serialization
             else
             {
                 object o = null;
-                if (type == typeof(System.Xml.Linq.XElement))
+                if (type.FullName == "System.Xml.Linq.XElement")
                 {
-                    o = new System.Xml.Linq.XElement("default");
+                    var xnameType = type.Assembly.GetType("System.Xml.Linq.XName");
+                    var xname = xnameType.GetMethod("Get", new[] { typeof(string) }).Invoke(null, new object[] { "default" });
+                    o = Activator.CreateInstance(type.Assembly.GetType("System.Xml.Linq.XElement"), xname);
                 }
                 else
                 {

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlCanonicalWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlCanonicalWriter.cs
@@ -7,6 +7,9 @@ using System.IO;
 using System.Runtime;
 using System.Runtime.Serialization;
 using System.Text;
+#if MONO
+using Fx = System.Runtime.Fx;
+#endif
 
 
 namespace System.Xml


### PR DESCRIPTION
A few BitArray tests sometimes fail with OOM - reproduces when there are not enough memory.
Also a few fixes for System.Runtime.Serialization:
XmlDataContract.cs - in all other places in this file System.Linq is used via reflection.