### PR TITLE
Remove merge marker, fix CS0177

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Xslt/XsltException.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xslt/XsltException.cs
@@ -147,10 +147,9 @@ namespace System.Xml.Xsl
     }
 
     [Serializable]
-<<<<<<< HEAD
-=======
+#if !MONO
     [System.Runtime.CompilerServices.TypeForwardedFrom("System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
->>>>>>> upstream/master
+#endif
     public class XsltCompileException : XsltException
     {
         protected XsltCompileException(SerializationInfo info, StreamingContext context) : base(info, context)

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/DateTimeHelper.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/DateTimeHelper.cs
@@ -44,6 +44,7 @@ namespace System.ServiceModel.Syndication
 
         private static bool Rfc3339DateTimeParser(string dateTimeString, out DateTimeOffset dto)
         {
+            dto = default(DateTimeOffset);
             dateTimeString = dateTimeString.Trim();
             if (dateTimeString.Length < 20)
             {
@@ -67,6 +68,7 @@ namespace System.ServiceModel.Syndication
 
         private static bool Rfc822DateTimeParser(string dateTimeString, out DateTimeOffset dto)
         {
+            dto = default(DateTimeOffset);
             StringBuilder dateTimeStringBuilder = new StringBuilder(dateTimeString.Trim());
             if (dateTimeStringBuilder.Length < 18)
             {

--- a/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeedFormatter.cs
+++ b/src/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/SyndicationFeedFormatter.cs
@@ -55,6 +55,7 @@ namespace System.ServiceModel.Syndication
 
         private bool NotImplementedDateTimeParser(XmlDateTimeData XmlDateTimeData, out DateTimeOffset dateTimeOffset)
         {
+            dateTimeOffset = default(DateTimeOffset);
             return false;
         }
 
@@ -430,7 +431,7 @@ namespace System.ServiceModel.Syndication
         {
             try
             {
-                DateTimeOffset dateTimeOffset;
+                DateTimeOffset dateTimeOffset = default(DateTimeOffset);
                 var elementQualifiedName = new XmlQualifiedName(reader.LocalName, reader.NamespaceURI);
                 var xmlDateTimeData = new XmlDateTimeData(dateTimeString, elementQualifiedName);
                 object[] args = new object[] { xmlDateTimeData, dateTimeOffset };


### PR DESCRIPTION
.NET Core compiles code using empty reference assemblies so it's not required to assign values to value types, but it won't work on mono.