### PR TITLE
[System.Private.Xml.Linq] port the fix to support existing implementation for converting XElement

### DIFF
--- a/src/System.Private.Xml.Linq/src/System/Xml/Linq/XElement.cs
+++ b/src/System.Private.Xml.Linq/src/System/Xml/Linq/XElement.cs
@@ -1866,7 +1866,7 @@ namespace System.Xml.Linq
             return XmlConvert.ToGuid(element.Value);
         }
 
-#if MONO
+#if MONO_HYBRID_SYSTEM_XML
         static object ConvertForAssignment (object value)
         {
             var node = value as XmlNode;

--- a/src/System.Private.Xml.Linq/src/System/Xml/Linq/XElement.cs
+++ b/src/System.Private.Xml.Linq/src/System/Xml/Linq/XElement.cs
@@ -35,6 +35,9 @@ namespace System.Xml.Linq
     ///     <item><see cref="XProcessingInstruction"/></item>
     ///   </list>
     /// </remarks>
+#if MONO_HYBRID_SYSTEM_XML
+    [XmlTypeConvertor ("ConvertForAssignment")]
+#endif
     [XmlSchemaProvider(null, IsAny = true)]
     public class XElement : XContainer, IXmlSerializable
     {
@@ -1862,6 +1865,18 @@ namespace System.Xml.Linq
             if (element == null) return null;
             return XmlConvert.ToGuid(element.Value);
         }
+
+#if MONO
+        static object ConvertForAssignment (object value)
+        {
+            var node = value as XmlNode;
+            if (node == null)
+                return value;
+            var doc = new XmlDocument ();
+            doc.AppendChild (doc.ImportNode (node, true));
+            return XElement.Parse (doc.InnerXml);
+        }
+#endif
 
         /// <summary>
         /// This method is obsolete for the IXmlSerializable contract.


### PR DESCRIPTION
This fixes [test failures](https://gist.github.com/MaximLipnin/8c19150f5740c9d35bf45a1dad8d2a0b).
Related to https://github.com/mono/mono/issues/8122

Reference to old issue:
Bug: https://bugzilla.xamarin.com/show_bug.cgi?id=12571
Commit: https://github.com/mono/mono/commit/2d573ae1ceac1656f0293cca3736dcb10c28be38#diff-540f710f00de5211a5d25a96cb442d01