### PR TITLE
Revert "Explicitly throw NRE in unsafe StringBuilder.Append"

### DIFF
--- a/src/Common/src/CoreLib/System/Text/StringBuilder.cs
+++ b/src/Common/src/CoreLib/System/Text/StringBuilder.cs
@@ -1879,11 +1879,7 @@ namespace System.Text
         [CLSCompliant(false)]
         public unsafe StringBuilder Append(char* value, int valueCount)
         {
-            if (value == null)
-            {
-                throw new NullReferenceException();
-            }
-
+            // We don't check null value as this case will throw null reference exception anyway
             if (valueCount < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(valueCount), SR.ArgumentOutOfRange_NegativeCount);


### PR DESCRIPTION
Reverts mono/corefx#48