### PR TITLE
Initial AIX support in System.Native/PAL

### DIFF
--- a/src/Native/Unix/System.Native/pal_errno.c
+++ b/src/Native/Unix/System.Native/pal_errno.c
@@ -130,8 +130,10 @@ int32_t SystemNative_ConvertErrorPlatformToPal(int32_t platformErrno)
             return Error_ENOTCONN;
         case ENOTDIR:
             return Error_ENOTDIR;
+#if !defined(_AIX)
         case ENOTEMPTY:
             return Error_ENOTEMPTY;
+#endif
 #ifdef ENOTRECOVERABLE // not available in NetBSD
         case ENOTRECOVERABLE:
             return Error_ENOTRECOVERABLE;

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -2,6 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#ifdef _AIX
+// For getline (declare this before stdio)
+#define _GETDELIM 1
+#endif
+
 #include "pal_compiler.h"
 #include "pal_config.h"
 #include "pal_errno.h"
@@ -35,6 +40,13 @@
 #endif
 #if HAVE_INOTIFY
 #include <sys/inotify.h>
+#endif
+
+#if defined(_AIX)
+#include <alloca.h>
+// Somehow, AIX mangles the definition for this behind a C++ def
+// Redeclare it here
+extern int     getpeereid(int, uid_t *__restrict__, gid_t *__restrict__);
 #endif
 
 #if HAVE_STAT64
@@ -78,6 +90,8 @@ c_static_assert(PAL_S_IFSOCK == S_IFSOCK);
 
 // Validate that our enum for inode types is the same as what is
 // declared by the dirent.h header on the local system.
+// (AIX doesn't have dirent d_type, so none of this there)
+#if !defined(_AIX)
 c_static_assert(PAL_DT_UNKNOWN == DT_UNKNOWN);
 c_static_assert(PAL_DT_FIFO == DT_FIFO);
 c_static_assert(PAL_DT_CHR == DT_CHR);
@@ -87,6 +101,7 @@ c_static_assert(PAL_DT_REG == DT_REG);
 c_static_assert(PAL_DT_LNK == DT_LNK);
 c_static_assert(PAL_DT_SOCK == DT_SOCK);
 c_static_assert(PAL_DT_WHT == DT_WHT);
+#endif
 
 // Validate that our Lock enum value are correct for the platform
 c_static_assert(PAL_LOCK_SH == LOCK_SH);
@@ -325,7 +340,30 @@ static void ConvertDirent(const struct dirent* entry, struct DirectoryEntry* out
     // the start of the unmanaged string. Give the caller back a pointer to the
     // location of the start of the string that exists in their own byte buffer.
     outputEntry->Name = entry->d_name;
+#if defined(_AIX)
+    /* AIX has no d_type, make a substitute */
+    struct stat s;
+    stat(entry->d_name, &s);
+    if (S_ISDIR(s.st_mode)) {
+        outputEntry->InodeType = PAL_DT_DIR;
+    } else if (S_ISFIFO(s.st_mode)) {
+        outputEntry->InodeType = PAL_DT_FIFO;
+    } else if (S_ISCHR(s.st_mode)) {
+        outputEntry->InodeType = PAL_DT_CHR;
+    } else if (S_ISBLK(s.st_mode)) {
+        outputEntry->InodeType = PAL_DT_BLK;
+    } else if (S_ISREG(s.st_mode)) {
+        outputEntry->InodeType = PAL_DT_REG;
+    } else if (S_ISLNK(s.st_mode)) {
+        outputEntry->InodeType = PAL_DT_LNK;
+    } else if (S_ISSOCK(s.st_mode)) {
+        outputEntry->InodeType = PAL_DT_SOCK;
+    } else {
+        outputEntry->InodeType = PAL_DT_UNKNOWN;
+    }
+#else
     outputEntry->InodeType = (int32_t)entry->d_type;
+#endif
 
 #if HAVE_DIRENT_NAME_LEN
     outputEntry->NameLength = entry->d_namlen;

--- a/src/Native/Unix/System.Native/pal_io.h
+++ b/src/Native/Unix/System.Native/pal_io.h
@@ -15,6 +15,12 @@ BEGIN_EXTERN_C
 #include <dirent.h>
 #include <sys/types.h>
 
+#if defined(_AIX) && !defined(O_CLOEXEC)
+/* HACK: Get AIX 6.1 working */
+#define O_CLOEXEC 0
+#define F_DUPFD_CLOEXEC 0
+#endif
+
 /**
  * File status returned by Stat or FStat.
  */
@@ -267,12 +273,22 @@ enum SysConfName
  */
 enum PollEvents
 {
+#if defined(_AIX)
+/* of course AIX is different */
+    PAL_POLLIN = 0x0001,   /* non-urgent readable data available */
+    PAL_POLLPRI = 0x0004,  /* urgent readable data available */
+    PAL_POLLOUT = 0x0002,  /* data can be written without blocked */
+    PAL_POLLERR = 0x4000,  /* an error occurred */
+    PAL_POLLHUP = 0x2000,  /* the file descriptor hung up */
+    PAL_POLLNVAL = 0x8000, /* the requested events were invalid */
+#else
     PAL_POLLIN = 0x0001,   /* non-urgent readable data available */
     PAL_POLLPRI = 0x0002,  /* urgent readable data available */
     PAL_POLLOUT = 0x0004,  /* data can be written without blocked */
     PAL_POLLERR = 0x0008,  /* an error occurred */
     PAL_POLLHUP = 0x0010,  /* the file descriptor hung up */
     PAL_POLLNVAL = 0x0020, /* the requested events were invalid */
+#endif
 };
 
 /**

--- a/src/Native/Unix/System.Native/pal_maphardwaretype.c
+++ b/src/Native/Unix/System.Native/pal_maphardwaretype.c
@@ -76,8 +76,10 @@ uint16_t MapHardwareType(uint16_t nativeType)
             return NetworkInterfaceType_Atm;
         case IFT_MODEM:
             return NetworkInterfaceType_GenericModem;
+#if defined(IFT_IEEE1394)
         case IFT_IEEE1394:
             return NetworkInterfaceType_HighPerformanceSerialBus;
+#endif
         default:
             return NetworkInterfaceType_Unknown;
     }

--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -20,6 +20,8 @@
 #include <sys/types.h>
 #include <sys/event.h>
 #include <sys/time.h>
+#else
+#include <sys/poll.h>
 #endif
 #include <errno.h>
 #include <netdb.h>
@@ -39,14 +41,18 @@
 #endif
 #include <unistd.h>
 #include <pwd.h>
+#if !defined(_AIX)
 #if HAVE_SENDFILE_4
 #include <sys/sendfile.h>
 #elif HAVE_SENDFILE_6
 #include <sys/uio.h>
 #endif
+#endif
 #if !HAVE_IN_PKTINFO
 #include <net/if.h>
+#if !defined(_AIX)
 #include <ifaddrs.h>
+#endif
 #endif
 
 #if HAVE_KQUEUE
@@ -782,7 +788,7 @@ static int32_t GetIPv4PacketInformation(struct cmsghdr* controlMessage, struct I
     ConvertInAddrToByteArray(&packetInfo->Address.Address[0], NUM_BYTES_IN_IPV4_ADDRESS, &pktinfo->ipi_addr);
 #if HAVE_IN_PKTINFO
     packetInfo->InterfaceIndex = (int32_t)pktinfo->ipi_ifindex;
-#else
+#elif !defined(_AIX)
     packetInfo->InterfaceIndex = 0;
 
     struct ifaddrs* addrs;
@@ -2254,7 +2260,32 @@ static int32_t WaitForSocketEventsInner(int32_t port, struct SocketEvent* buffer
 }
 
 #else
-#error Asynchronous sockets require epoll or kqueue support.
+//#error Asynchronous sockets require epoll or kqueue support.
+// TODO: Poll fallback
+static const size_t SocketEventBufferElementSize = sizeof(struct pollmsg);
+
+static enum SocketEvents GetSocketEvents(int16_t filter, uint16_t flags)
+{
+    return SocketEvents_SA_NONE; 
+}
+static int32_t CloseSocketEventPortInner(int32_t port)
+{
+    return Error_ENOSYS;
+}
+static int32_t CreateSocketEventPortInner(int32_t* port)
+{
+    return Error_ENOSYS;
+}
+static int32_t TryChangeSocketEventRegistrationInner(
+    int32_t port, int32_t socket, enum SocketEvents currentEvents, enum SocketEvents newEvents,
+uintptr_t data)
+{
+    return Error_ENOSYS;
+}
+static int32_t WaitForSocketEventsInner(int32_t port, struct SocketEvent* buffer, int32_t* count)
+{
+    return Error_ENOSYS;
+}
 #endif
 
 int32_t SystemNative_CreateSocketEventPort(intptr_t* port)
@@ -2420,7 +2451,7 @@ int32_t SystemNative_SendFile(intptr_t out_fd, intptr_t in_fd, int64_t offset, i
     *sent = 0;
     return SystemNative_ConvertErrorPlatformToPal(errno);
 
-#elif HAVE_SENDFILE_6
+#elif HAVE_SENDFILE_6 && !defined(_AIX) /* why is AIX getting this? */
     *sent = 0;
     while (1) // in case we need to retry for an EINTR
     {

--- a/src/Native/Unix/System.Native/pal_random.c
+++ b/src/Native/Unix/System.Native/pal_random.c
@@ -39,7 +39,12 @@ void SystemNative_GetNonCryptographicallySecureRandomBytes(uint8_t* buffer, int3
 
             do
             {
+#ifdef O_CLOEXEC
                 fd = open("/dev/urandom", O_RDONLY, O_CLOEXEC);
+#else
+                fd = open("/dev/urandom", O_RDONLY, NULL);
+                fcntl(fd, F_SETFD, FD_CLOEXEC);
+#endif
             }
             while ((fd == -1) && (errno == EINTR));
 


### PR DESCRIPTION
The two ugliest hacks are:

* AIX 6.1, the lowest version we target, has FD_CLOEXEC without O_CLOEXEC. I believe the fake definition should work though, as since AIX doesn't have pipe2, it has to apply FD_CLOEXEC afterwards with fcntl.

* I ripped out the error for no epoll/kqueue and put nopped out versions of the async I/O stuff. I don't believe this is wired up yet, but I'll eventually turn this into a poll based fallback. (AIX has pollsets, but PASE only has select and poll.)

* I haven't implemented the bit dependent on ifaddrs. There is an alternative, but it's a disgusting amount of code, as you can compare in `mono/utils/networking-posix.c`.

For now, despite the nopping, it's enough to get the runtime to build as it did before on AIX, and get the where we were before.