### PR TITLE
System.Security.Cryptography.Pkcs

### DIFF
--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSigner.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSigner.cs
@@ -13,7 +13,11 @@ namespace System.Security.Cryptography.Pkcs
 {
     public sealed class CmsSigner
     {
+#if MONO
+        private static readonly Oid s_defaultAlgorithm = Oid.FromOidValue(Oids.Sha1, OidGroup.HashAlgorithm);
+#else
         private static readonly Oid s_defaultAlgorithm = Oid.FromOidValue(Oids.Sha256, OidGroup.HashAlgorithm);
+#endif
 
         public X509Certificate2 Certificate { get; set; }
         public X509Certificate2Collection Certificates { get; set; } = new X509Certificate2Collection();

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/EnvelopedCms.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/EnvelopedCms.cs
@@ -10,7 +10,7 @@ using Internal.Cryptography;
 
 namespace System.Security.Cryptography.Pkcs
 {
-    public sealed class EnvelopedCms
+    public sealed partial class EnvelopedCms
     {
         //
         // Constructors


### PR DESCRIPTION
Switch CmsSigner default algorithm to SHA-1 to match documented .NET Framework behaviour. Make EnvelopedCms class partial to allow adding methods to it.