### PR TITLE
Hide more forwarders from corlib on mono

### DIFF
--- a/src/Common/src/CoreLib/System/Boolean.cs
+++ b/src/Common/src/CoreLib/System/Boolean.cs
@@ -18,7 +18,9 @@ using System.Runtime.Versioning;
 namespace System
 {
     [Serializable]
+#if !MONO
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
     public struct Boolean : IComparable, IConvertible, IComparable<Boolean>, IEquatable<Boolean>
     {
         //

--- a/src/Common/src/CoreLib/System/Char.cs
+++ b/src/Common/src/CoreLib/System/Char.cs
@@ -20,7 +20,9 @@ namespace System
 {
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+#if !MONO
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
+#endif
     public struct Char : IComparable, IComparable<Char>, IEquatable<Char>, IConvertible
     {
         //

--- a/src/Common/src/CoreLib/System/InvalidTimeZoneException.cs
+++ b/src/Common/src/CoreLib/System/InvalidTimeZoneException.cs
@@ -7,7 +7,11 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+#if MONO
+    [System.Runtime.CompilerServices.TypeForwardedFrom("System.Core, Version=2.0.5.0, Culture=Neutral, PublicKeyToken=7cec85d7bea7798e")]
+#else
     [System.Runtime.CompilerServices.TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
     public class InvalidTimeZoneException : Exception
     {
         public InvalidTimeZoneException()

--- a/src/Common/src/CoreLib/System/TimeZoneNotFoundException.cs
+++ b/src/Common/src/CoreLib/System/TimeZoneNotFoundException.cs
@@ -7,7 +7,11 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+#if MONO
+    [System.Runtime.CompilerServices.TypeForwardedFrom("System.Core, Version=2.0.5.0, Culture=Neutral, PublicKeyToken=7cec85d7bea7798e")]
+#else
     [System.Runtime.CompilerServices.TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
     public class TimeZoneNotFoundException : Exception
     {
         public TimeZoneNotFoundException()


### PR DESCRIPTION
Not sure about `TimeZoneNotFoundException` and `InvalidTimeZoneException` (they had them in mono but with different values)