### PR TITLE
Fix number formatting exception with empty NumberGroupSizes array

### DIFF
--- a/src/Common/src/CoreLib/System/Number.Formatting.cs
+++ b/src/Common/src/CoreLib/System/Number.Formatting.cs
@@ -1974,14 +1974,15 @@ namespace System
             {
                 if (groupDigits != null)
                 {
-                    int groupSizeIndex = 0;                             // Index into the groupDigits array.
-                    int groupSizeCount = groupDigits[groupSizeIndex];   // The current total of group size.
+                    int groupSizeIndex = 0;                             // Index into the groupDigits array.                    
                     int bufferSize = digPos;                            // The length of the result buffer string.
                     int groupSize = 0;                                  // The current group size.
 
                     // Find out the size of the string buffer for the result.
                     if (groupDigits.Length != 0) // You can pass in 0 length arrays
                     {
+                        int groupSizeCount = groupDigits[groupSizeIndex];   // The current total of group size.
+
                         while (digPos > groupSizeCount)
                         {
                             groupSize = groupDigits[groupSizeIndex];


### PR DESCRIPTION
Cherry-pick https://github.com/dotnet/coreclr/pull/18221
For https://github.com/mono/mono/pull/8626#discussion_r194984329