### PR TITLE
Added ability to work with 'legacy' System.Configuration in Mono

### DIFF
--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigurationHost.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigurationHost.cs
@@ -46,9 +46,13 @@ namespace System.Configuration
             {
                 if (s_machineConfigFilePath == null)
                 {
+#if !MONO
                     string directory = AppDomain.CurrentDomain.BaseDirectory;
                     s_machineConfigFilePath = Path.Combine(Path.Combine(directory, MachineConfigSubdirectory),
                         MachineConfigFilename);
+#else
+                    s_machineConfigFilePath = DefaultConfig.MachineConfigPath;
+#endif
                 }
 
                 return s_machineConfigFilePath;

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/TypeUtil.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/TypeUtil.cs
@@ -7,9 +7,15 @@ using System.Reflection;
 
 namespace System.Configuration
 {
-    internal static class TypeUtil
+    internal static partial class TypeUtil
     {
+
+#if MONO
+        // Ensures we can load types from the old place.
+        internal const string ConfigurationManagerAssemblyName = "System.Configuration";
+#else
         internal const string ConfigurationManagerAssemblyName = "System.Configuration.ConfigurationManager";
+#endif
 
         // Deliberately not being explicit about the versions to make
         // things simpler for consumers of System.Configuration.


### PR DESCRIPTION
Modified corefx System.Configuration.ConfigurationManager to be Mono machine.config aware and work with System.Configuration.