### PR TITLE
Make Number.Parsing.cs Big Endian friendly

### DIFF
--- a/src/Common/src/CoreLib/System/Number.Parsing.cs
+++ b/src/Common/src/CoreLib/System/Number.Parsing.cs
@@ -962,13 +962,13 @@ namespace System
         private static class DoubleHelper
         {
             public static unsafe uint Exponent(double d) =>
-                (*((uint*)&d + 1) >> 20) & 0x000007ff;
+                (*((uint*)&d + (BitConverter.IsLittleEndian ? 1 : 0)) >> 20) & 0x000007ff;
 
             public static unsafe ulong Mantissa(double d) =>
                 *((ulong*)&d) & 0x000fffffffffffff;
 
             public static unsafe bool Sign(double d) =>
-                (*((uint*)&d + 1) >> 31) != 0;
+                (*((uint*)&d + (BitConverter.IsLittleEndian ? 1 : 0)) >> 31) != 0;
         }
     }
 }

--- a/src/System.Memory/src/System/Number/Number.FormatAndParse.cs
+++ b/src/System.Memory/src/System/Number/Number.FormatAndParse.cs
@@ -522,7 +522,7 @@ namespace System
         {
             public static unsafe uint Exponent(double d)
             {
-                return (*((uint*)&d + 1) >> 20) & 0x000007ff;
+                return (*((uint*)&d + (BitConverter.IsLittleEndian ? 1 : 0)) >> 20) & 0x000007ff;
             }
 
             public static unsafe ulong Mantissa(double d)
@@ -532,7 +532,7 @@ namespace System
 
             public static unsafe bool Sign(double d)
             {
-                return (*((uint*)&d + 1) >> 31) != 0;
+                return (*((uint*)&d + (BitConverter.IsLittleEndian ? 1 : 0)) >> 31) != 0;
             }
         }
     }


### PR DESCRIPTION
In order to pass these tests: https://gist.github.com/EgorBo/e0cb42e7724f6653bee563318386be25
without these changes https://github.com/mono/mono/pull/8626 did not even compile, MCS used to fail trying to parse several constants (like Double.MinValue).
 