### PR TITLE
ProtectedData: make unit test windows-specific

### DIFF
--- a/src/System.Security.Cryptography.ProtectedData/tests/ProtectedDataTests.cs
+++ b/src/System.Security.Cryptography.ProtectedData/tests/ProtectedDataTests.cs
@@ -15,6 +15,7 @@ namespace System.Security.Cryptography.ProtectedDataTests
     public static class ProtectedDataTests
     {
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public static void RoundTrip()
         {
             RoundTrip(null);
@@ -38,6 +39,7 @@ namespace System.Security.Cryptography.ProtectedDataTests
         [InlineData(DataProtectionScope.CurrentUser, true)]
         [InlineData(DataProtectionScope.LocalMachine, false)]
         [InlineData(DataProtectionScope.LocalMachine, true)]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public static void ProtectEmptyData(DataProtectionScope scope, bool useEntropy)
         {
             // Use new byte[0] instead of Array.Empty<byte> to prove the implementation
@@ -52,6 +54,7 @@ namespace System.Security.Cryptography.ProtectedDataTests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public static void NullEntropyEquivalence()
         {
             // Passing a zero-length array as entropy is equivalent to passing null as entropy.
@@ -63,6 +66,7 @@ namespace System.Security.Cryptography.ProtectedDataTests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public static void NullEntropyEquivalence2()
         {
             // Passing a zero-length array as entropy is equivalent to passing null as entropy.
@@ -74,6 +78,7 @@ namespace System.Security.Cryptography.ProtectedDataTests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public static void WrongEntropy()
         {
             // Passing a zero-length array as entropy is equivalent to passing null as entropy.


### PR DESCRIPTION
There is no (and seems won't be) managed implementation for ProtectedData in CoreFX. So related xunit tests are actual only for Windows. To avoid failures on non-windows targets I added [PlatformSpecific(TestPlatforms.Windows)] attribute. That's suggested in https://github.com/mono/mono/issues/9395.
