### PR TITLE
System.IO.Pipes: Additional changes to implement Windows-specific constructors

### DIFF
--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
@@ -16,6 +16,10 @@ namespace System.IO.Pipes
     /// </summary>
     public sealed partial class NamedPipeClientStream : PipeStream
     {
+#if MONO
+        int _access = 0;
+#endif
+
         // Waits for a pipe instance to become available. This method may return before WaitForConnection is called
         // on the server end, but WaitForConnection will not return until we have returned.  Any data written to the
         // pipe by us after we have connected but before the server has called WaitForConnection will be available
@@ -34,7 +38,11 @@ namespace System.IO.Pipes
                 _pipeFlags |= (((int)_impersonationLevel - 1) << 16);
             }
 
+#if MONO
+            int access = _access;
+#else
             int access = 0;
+#endif
             if ((PipeDirection.In & _direction) != 0)
             {
                 access |= Interop.Kernel32.GenericOperations.GENERIC_READ;

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
@@ -16,10 +16,6 @@ namespace System.IO.Pipes
     /// </summary>
     public sealed partial class NamedPipeClientStream : PipeStream
     {
-#if MONO
-        int _access = 0;
-#endif
-
         // Waits for a pipe instance to become available. This method may return before WaitForConnection is called
         // on the server end, but WaitForConnection will not return until we have returned.  Any data written to the
         // pipe by us after we have connected but before the server has called WaitForConnection will be available

--- a/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
@@ -24,6 +24,15 @@ namespace System.IO.Pipes
                 PipeTransmissionMode transmissionMode, PipeOptions options, int inBufferSize, int outBufferSize,
                 HandleInheritability inheritability)
         {
+            Create(pipeName, direction, maxNumberOfServerInstances, transmissionMode, options, inBufferSize,
+                outBufferSize, null, inheritability, 0);
+        }
+
+        // This overload is used in Mono to implement public constructors.
+        private void Create(string pipeName, PipeDirection direction, int maxNumberOfServerInstances,
+                PipeTransmissionMode transmissionMode, PipeOptions options, int inBufferSize, int outBufferSize,
+                PipeSecurity pipeSecurity, HandleInheritability inheritability, PipeAccessRights additionalAccessRights)
+        {
             Debug.Assert(pipeName != null && pipeName.Length != 0, "fullPipeName is null or empty");
             Debug.Assert(direction >= PipeDirection.In && direction <= PipeDirection.InOut, "invalid pipe direction");
             Debug.Assert(inBufferSize >= 0, "inBufferSize is negative");
@@ -39,10 +48,10 @@ namespace System.IO.Pipes
                 throw new ArgumentOutOfRangeException(nameof(pipeName), SR.ArgumentOutOfRange_AnonymousReserved);
             }
 
-            PipeSecurity pipeSecurity = null;
-
             if (IsCurrentUserOnly)
             {
+                Debug.Assert(pipeSecurity == null);
+
                 using (WindowsIdentity currentIdentity = WindowsIdentity.GetCurrent())
                 {
                     SecurityIdentifier identifier = currentIdentity.Owner;
@@ -64,7 +73,8 @@ namespace System.IO.Pipes
 
             int openMode = ((int)direction) |
                            (maxNumberOfServerInstances == 1 ? Interop.Kernel32.FileOperations.FILE_FLAG_FIRST_PIPE_INSTANCE : 0) |
-                           (int)options;
+                           (int)options |
+                           (int)additionalAccessRights;
 
             // We automatically set the ReadMode to match the TransmissionMode.
             int pipeModes = (int)transmissionMode << 2 | (int)transmissionMode << 1;


### PR DESCRIPTION
The big commit is cherry-picked from upstream, the small commit is local.