### PR TITLE
Fix compilation errors on Linux kernel < 3.9 (SO_REUSEPORT is not defined)

### DIFF
--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -1712,6 +1712,7 @@ int32_t SystemNative_GetSockOpt(
             }
 
             socklen_t optLen = (socklen_t)*optionLen;
+#ifdef SO_REUSEPORT
             // On Unix, SO_REUSEPORT controls the ability to bind multiple sockets to the same address.
             int err = getsockopt(fd, SOL_SOCKET, SO_REUSEPORT, optionValue, &optLen);
 
@@ -1731,7 +1732,9 @@ int32_t SystemNative_GetSockOpt(
                 value = value == 0 ? 1 : 0;
             }
             *(int32_t*)optionValue = value;
-
+#else
+            return Error_ENOTSUP;
+#endif
             return Error_SUCCESS;
         }
     }
@@ -1790,6 +1793,7 @@ SystemNative_SetSockOpt(intptr_t socket, int32_t socketOptionLevel, int32_t sock
         // We make both SocketOptionName_SO_REUSEADDR and SocketOptionName_SO_EXCLUSIVEADDRUSE control SO_REUSEPORT.
         if (socketOptionName == SocketOptionName_SO_EXCLUSIVEADDRUSE || socketOptionName == SocketOptionName_SO_REUSEADDR)
         {
+#ifdef SO_REUSEPORT
             if (optionLen != sizeof(int32_t))
             {
                 return Error_EINVAL;
@@ -1812,6 +1816,9 @@ SystemNative_SetSockOpt(intptr_t socket, int32_t socketOptionLevel, int32_t sock
 
             int err = setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &value, (socklen_t)optionLen);
             return err == 0 ? Error_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
+#else
+            return Error_ENOTSUP;
+#endif
         }
     }
 #ifdef IP_MTU_DISCOVER

--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -1711,8 +1711,8 @@ int32_t SystemNative_GetSockOpt(
                 return Error_EINVAL;
             }
 
-            socklen_t optLen = (socklen_t)*optionLen;
 #ifdef SO_REUSEPORT
+            socklen_t optLen = (socklen_t)*optionLen;
             // On Unix, SO_REUSEPORT controls the ability to bind multiple sockets to the same address.
             int err = getsockopt(fd, SOL_SOCKET, SO_REUSEPORT, optionValue, &optLen);
 
@@ -1733,7 +1733,7 @@ int32_t SystemNative_GetSockOpt(
             }
             *(int32_t*)optionValue = value;
 #else
-            return Error_ENOTSUP;
+            *optionValue = 0;
 #endif
             return Error_SUCCESS;
         }
@@ -1817,7 +1817,7 @@ SystemNative_SetSockOpt(intptr_t socket, int32_t socketOptionLevel, int32_t sock
             int err = setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &value, (socklen_t)optionLen);
             return err == 0 ? Error_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 #else
-            return Error_ENOTSUP;
+            return Error_SUCCESS;
 #endif
         }
     }


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/9439
IMO it should throw NotSupported error instead of hidden no-op, shouldn't it?
Does it make sense to upstream this change as it seems the minimal Linux Kernel version .NET Core officially supports is 3.14 ? (`SO_REUSEPORT` was introduced in 3.9)

cc @nealef 