### PR TITLE
Workaround for mcs issue in AsnWriter

### DIFF
--- a/src/Common/src/System/Security/Cryptography/AsnWriter.cs
+++ b/src/Common/src/System/Security/Cryptography/AsnWriter.cs
@@ -1214,7 +1214,13 @@ namespace System.Security.Cryptography.Asn1
 #endif
 
                     decimal decimalTicks = floatingTicks;
+
+#if __MonoCS__
+                    /* bug in mcs is making it pick the wrong overload, only manifesting in BE? */
+                    decimalTicks = decimal.Divide(decimalTicks, new decimal(TimeSpan.TicksPerSecond));
+#else
                     decimalTicks /= TimeSpan.TicksPerSecond;
+#endif
 
                     if (!Utf8Formatter.TryFormat(decimalTicks, fraction, out int bytesWritten, new StandardFormat('G')))
                     {


### PR DESCRIPTION
Only seems to be triggered on big endian; @EgorBo believes it's the
wrong overload, but I'm not sure.

(note to debug DecimalConstant.Emit in mcs later; for now I would
like CI lanes for AIX working again to assess the repercussions
of CoreFX imports)

See mono/mono#9684