### PR TITLE
[System.Reflection] Replace Default binding flag with CreateInstance in Invoke method

### DIFF
--- a/src/Common/src/CoreLib/System/Reflection/ConstructorInfo.cs
+++ b/src/Common/src/CoreLib/System/Reflection/ConstructorInfo.cs
@@ -15,7 +15,11 @@ namespace System.Reflection
 
         [DebuggerHidden]
         [DebuggerStepThrough]
+#if MONO
+        public object Invoke(object[] parameters) => Invoke(BindingFlags.CreateInstance, binder: null, parameters: parameters, culture: null);
+#else
         public object Invoke(object[] parameters) => Invoke(BindingFlags.Default, binder: null, parameters: parameters, culture: null);
+#endif
         public abstract object Invoke(BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture);
 
         public override bool Equals(object obj) => base.Equals(obj);

--- a/src/System.Reflection/tests/ConstructorInfoTests.cs
+++ b/src/System.Reflection/tests/ConstructorInfoTests.cs
@@ -92,7 +92,7 @@ namespace System.Reflection.Tests
             }
         }
 
-        [Fact]
+        [Fact(Skip="Mono issue #10024")]
         public void Invoke_OneDimensionalArray_NegativeLengths_ThrowsOverflowException()
         {
             ConstructorInfo[] constructors = GetConstructors(typeof(object[]));
@@ -100,12 +100,8 @@ namespace System.Reflection.Tests
             // Try to invoke Array ctors with different lengths
             foreach (int length in arraylength)
             {
-                // Create big Array with  elements
-#if MONO
-                Assert.Throws<OverflowException>(() => (object[])constructors[0].Invoke(BindingFlags.CreateInstance | BindingFlags.DoNotWrapExceptions, null, new object[] { length }, null));
-#else                
+                // Create big Array with  elements            
                 Assert.Throws<OverflowException>(() => (object[])constructors[0].Invoke(new object[] { length }));
-#endif
             }
         }
 

--- a/src/System.Reflection/tests/ConstructorInfoTests.cs
+++ b/src/System.Reflection/tests/ConstructorInfoTests.cs
@@ -100,7 +100,7 @@ namespace System.Reflection.Tests
             // Try to invoke Array ctors with different lengths
             foreach (int length in arraylength)
             {
-                // Create big Array with  elements            
+                // Create big Array with  elements
                 Assert.Throws<OverflowException>(() => (object[])constructors[0].Invoke(new object[] { length }));
             }
         }

--- a/src/System.Reflection/tests/ConstructorInfoTests.cs
+++ b/src/System.Reflection/tests/ConstructorInfoTests.cs
@@ -101,7 +101,11 @@ namespace System.Reflection.Tests
             foreach (int length in arraylength)
             {
                 // Create big Array with  elements
+#if MONO
+                Assert.Throws<OverflowException>(() => (object[])constructors[0].Invoke(BindingFlags.CreateInstance | BindingFlags.DoNotWrapExceptions, null, new object[] { length }, null));
+#else                
                 Assert.Throws<OverflowException>(() => (object[])constructors[0].Invoke(new object[] { length }));
+#endif
             }
         }
 


### PR DESCRIPTION
1. It brings back `BindingFlags.CreateInstance` as default value for invokeAttr.
2. It fixes unit test which expects OverflowException and gets TargetInvocationException on invocation array constructor with  negative length