### PR TITLE
Use icall for Math.Round

### DIFF
--- a/src/Common/src/CoreLib/System/Math.cs
+++ b/src/Common/src/CoreLib/System/Math.cs
@@ -644,6 +644,7 @@ namespace System
             return decimal.Round(d, decimals, mode);
         }
 
+#if !MONO
         [Intrinsic]
         public static double Round(double a)
         {
@@ -672,6 +673,10 @@ namespace System
 
             return copysign(flrTempVal, a);
         }
+#else
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        public static extern double Round(double a);
+#endif
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double Round(double value, int digits)


### PR DESCRIPTION
Bring back icall for Math.Round instead of managed implementation since it regresses performance on CPU without SSE41 (with SSE41 managed implementation will be replaced).
Needed for https://github.com/mono/mono/pull/10033