### PR TITLE
CoreFX PAL for Haiku

### DIFF
--- a/src/Native/Unix/Common/pal_config.h.in
+++ b/src/Native/Unix/Common/pal_config.h.in
@@ -9,6 +9,7 @@
 #cmakedefine01 HAVE_F_DUPFD_CLOEXEC
 #cmakedefine01 HAVE_O_CLOEXEC
 #cmakedefine01 HAVE_GETIFADDRS
+#cmakedefine01 HAVE_UTSNAME_DOMAINNAME
 #cmakedefine01 HAVE_STAT64
 #cmakedefine01 HAVE_PIPE2
 #cmakedefine01 HAVE_STAT_BIRTHTIME
@@ -36,6 +37,7 @@
 #cmakedefine01 HAVE_FDS_BITS
 #cmakedefine01 HAVE_PRIVATE_FDS_BITS
 #cmakedefine01 HAVE_STATFS
+#cmakedefine01 HAVE_SYS_SOCKIO_H
 #cmakedefine01 HAVE_SYS_POLL_H
 #cmakedefine01 HAVE_EPOLL
 #cmakedefine01 HAVE_ACCEPT4

--- a/src/Native/Unix/System.Native/pal_errno.c
+++ b/src/Native/Unix/System.Native/pal_errno.c
@@ -178,8 +178,10 @@ int32_t SystemNative_ConvertErrorPlatformToPal(int32_t platformErrno)
             return Error_ETXTBSY;
         case EXDEV:
             return Error_EXDEV;
+#ifdef ESOCKTNOSUPPORT
         case ESOCKTNOSUPPORT:
             return Error_ESOCKTNOSUPPORT;
+#endif
         case EPFNOSUPPORT:
             return Error_EPFNOSUPPORT;
         case ESHUTDOWN:
@@ -366,8 +368,10 @@ int32_t SystemNative_ConvertErrorPalToPlatform(int32_t error)
             return EXDEV;
         case Error_EPFNOSUPPORT:
             return EPFNOSUPPORT;
+#ifdef ESOCKTNOSUPPORT:
         case Error_ESOCKTNOSUPPORT:
             return ESOCKTNOSUPPORT;
+#endif
         case Error_ESHUTDOWN:
             return ESHUTDOWN;
         case Error_EHOSTDOWN:

--- a/src/Native/Unix/System.Native/pal_errno.c
+++ b/src/Native/Unix/System.Native/pal_errno.c
@@ -368,7 +368,7 @@ int32_t SystemNative_ConvertErrorPalToPlatform(int32_t error)
             return EXDEV;
         case Error_EPFNOSUPPORT:
             return EPFNOSUPPORT;
-#ifdef ESOCKTNOSUPPORT:
+#ifdef ESOCKTNOSUPPORT
         case Error_ESOCKTNOSUPPORT:
             return ESOCKTNOSUPPORT;
 #endif

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -120,17 +120,6 @@ c_static_assert(PAL_SEEK_SET == SEEK_SET);
 c_static_assert(PAL_SEEK_CUR == SEEK_CUR);
 c_static_assert(PAL_SEEK_END == SEEK_END);
 
-// Validate our PollFlags enum values are correct for the platform
-// HACK: AIX and Haiku values are different; we convert them between PAL_POLL and POLL now
-#if !(defined (_AIX) || defined (__HAIKU__))
-c_static_assert(PAL_POLLIN == POLLIN);
-c_static_assert(PAL_POLLPRI == POLLPRI);
-c_static_assert(PAL_POLLOUT == POLLOUT);
-c_static_assert(PAL_POLLERR == POLLERR);
-c_static_assert(PAL_POLLHUP == POLLHUP);
-c_static_assert(PAL_POLLNVAL == POLLNVAL);
-#endif
-
 // Validate our FileAdvice enum values are correct for the platform
 #if HAVE_POSIX_ADVISE
 c_static_assert(PAL_POSIX_FADV_NORMAL == POSIX_FADV_NORMAL);
@@ -1452,7 +1441,7 @@ int32_t SystemNative_LockFileRegion(intptr_t fd, int64_t offset, int64_t length,
         return -1;
     }
 
-#if HAVE_FLOCK64 && !defined (__HAIKU__)
+#if HAVE_FLOCK64
     struct flock64 lockArgs;
 #else
     struct flock lockArgs;

--- a/src/Native/Unix/System.Native/pal_maphardwaretype.c
+++ b/src/Native/Unix/System.Native/pal_maphardwaretype.c
@@ -56,27 +56,39 @@ uint16_t MapHardwareType(uint16_t nativeType)
     {
         case IFT_ETHER:
             return NetworkInterfaceType_Ethernet;
+#ifdef IFT_ISO88025
         case IFT_ISO88025:
             return NetworkInterfaceType_TokenRing;
+#endif
+#ifdef IFT_FDDI
         case IFT_FDDI:
             return NetworkInterfaceType_Fddi;
+#endif
+#ifdef IFT_ISDNBASIC
         case IFT_ISDNBASIC:
             return NetworkInterfaceType_Isdn;
+#endif
+#ifdef IFT_ISDNPRIMARY
         case IFT_ISDNPRIMARY:
             return NetworkInterfaceType_PrimaryIsdn;
+#endif
         case IFT_PPP:
             return NetworkInterfaceType_Ppp;
         case IFT_LOOP:
             return NetworkInterfaceType_Loopback;
+#ifdef IFT_XETHER
         case IFT_XETHER:
             return NetworkInterfaceType_Ethernet3Megabit;
+#endif
         case IFT_SLIP:
             return NetworkInterfaceType_Slip;
+#ifdef IFT_ATM
         case IFT_ATM:
             return NetworkInterfaceType_Atm;
+#endif
         case IFT_MODEM:
             return NetworkInterfaceType_GenericModem;
-#if defined(IFT_IEEE1394)
+#ifdef IFT_IEEE1394
         case IFT_IEEE1394:
             return NetworkInterfaceType_HighPerformanceSerialBus;
 #endif

--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -31,6 +31,10 @@
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#if defined (__HAIKU__)
+#include <sys/time.h>
+#include <sys/sockio.h>
+#endif
 #include <sys/un.h>
 #if defined(__APPLE__) && __APPLE__
 #include <sys/socketvar.h>
@@ -49,6 +53,10 @@
 #if !HAVE_IN_PKTINFO
 #include <net/if.h>
 #if HAVE_GETIFADDRS
+#if defined (__HAIKU__)
+// Haiku needs this define for getifaddrs
+#define _BSD_SOURCE
+#endif
 #include <ifaddrs.h>
 #endif
 #endif
@@ -400,7 +408,7 @@ int32_t SystemNative_GetDomainName(uint8_t* name, int32_t nameLength)
 #endif
 
     return getdomainname((char*)name, namelen);
-#elif HAVE_UNAME
+#elif HAVE_UNAME && !defined (__HAIKU__)
     // On Android, there's no getdomainname but we can use uname to fetch the domain name
     // of the current device
     size_t namelen = (uint32_t)nameLength;
@@ -1852,9 +1860,11 @@ static bool TryConvertSocketTypePalToPlatform(int32_t palSocketType, int* platfo
             *platformSocketType = SOCK_RAW;
             return true;
 
+#ifdef SOCK_RDM
         case SocketType_SOCK_RDM:
             *platformSocketType = SOCK_RDM;
             return true;
+#endif
 
         case SocketType_SOCK_SEQPACKET:
             *platformSocketType = SOCK_SEQPACKET;

--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -14,12 +14,12 @@
 #include <pthread.h>
 #include <arpa/inet.h>
 #include <assert.h>
+#include <sys/time.h>
 #if HAVE_EPOLL
 #include <sys/epoll.h>
 #elif HAVE_KQUEUE
 #include <sys/types.h>
 #include <sys/event.h>
-#include <sys/time.h>
 #elif HAVE_SYS_POLL_H
 #include <sys/poll.h>
 #endif
@@ -31,15 +31,14 @@
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
-#if defined (__HAIKU__)
-#include <sys/time.h>
+#if HAVE_SYS_SOCKIO_H
 #include <sys/sockio.h>
 #endif
 #include <sys/un.h>
 #if defined(__APPLE__) && __APPLE__
 #include <sys/socketvar.h>
 #endif
-#if !HAVE_GETDOMAINNAME && HAVE_UNAME
+#if !HAVE_GETDOMAINNAME && HAVE_UTSNAME_DOMAINNAME
 #include <sys/utsname.h>
 #include <stdio.h>
 #endif
@@ -53,10 +52,6 @@
 #if !HAVE_IN_PKTINFO
 #include <net/if.h>
 #if HAVE_GETIFADDRS
-#if defined (__HAIKU__)
-// Haiku needs this define for getifaddrs
-#define _BSD_SOURCE
-#endif
 #include <ifaddrs.h>
 #endif
 #endif
@@ -408,7 +403,7 @@ int32_t SystemNative_GetDomainName(uint8_t* name, int32_t nameLength)
 #endif
 
     return getdomainname((char*)name, namelen);
-#elif HAVE_UNAME && !defined (__HAIKU__)
+#elif HAVE_UTSNAME_DOMAINNAME
     // On Android, there's no getdomainname but we can use uname to fetch the domain name
     // of the current device
     size_t namelen = (uint32_t)nameLength;

--- a/src/Native/Unix/System.Native/pal_tcpstate.c
+++ b/src/Native/Unix/System.Native/pal_tcpstate.c
@@ -11,7 +11,7 @@
 #elif HAVE_TCP_H_TCPSTATE_ENUM
 #include <netinet/tcp.h>
 #else
-#error System must have TCP states defined in either tcp.h or tcp_fsm.h.
+#warning System doesn't have TCP states defined in either tcp.h or tcp_fsm.h; falling back to always returning unknown.
 #endif
 
 int32_t SystemNative_MapTcpState(int32_t tcpState)
@@ -64,6 +64,9 @@ int32_t SystemNative_MapTcpState(int32_t tcpState)
             return TcpState_Listen;
         case TCP_CLOSING:
             return TcpState_Closing;
+        default:
+            return TcpState_Unknown;
+#else
         default:
             return TcpState_Unknown;
 #endif

--- a/src/Native/Unix/System.Native/pal_tcpstate.c
+++ b/src/Native/Unix/System.Native/pal_tcpstate.c
@@ -39,8 +39,6 @@ int32_t SystemNative_MapTcpState(int32_t tcpState)
             return TcpState_FinWait2;
         case TCPS_TIME_WAIT:
             return TcpState_TimeWait;
-        default:
-            return TcpState_Unknown;
 #elif HAVE_TCP_H_TCPSTATE_ENUM
         case TCP_ESTABLISHED:
             return TcpState_Established;
@@ -64,11 +62,8 @@ int32_t SystemNative_MapTcpState(int32_t tcpState)
             return TcpState_Listen;
         case TCP_CLOSING:
             return TcpState_Closing;
-        default:
-            return TcpState_Unknown;
-#else
-        default:
-            return TcpState_Unknown;
 #endif
+        default:
+            return TcpState_Unknown;
     }
 }


### PR DESCRIPTION
Been a while since I last tested, but the changes have gotten merged in upstream. This syncs them over, covers parts upstream removed, etc.

Minor tweaks to update checks (sockio.h, if it isn't covered already, and utsname.domainname) in the root module if the submodule is updated would be needed. See dotnet/corefx#31083