### PR TITLE
Add CloseCore to RegistryKey

### DIFF
--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
@@ -98,8 +98,15 @@ namespace Microsoft.Win32
             FlushCore();
         }
 
+#if MONO
+        partial void CloseCore();
+#endif
+
         public void Close()
         {
+#if MONO
+            CloseCore();
+#endif
             Dispose();
         }
 


### PR DESCRIPTION
To be able to override it in RegistryKey.FileSystem implementation, needed for https://github.com/mono/mono/pull/9855
All other platform-specific methods also have "Core" as a suffix in this type.