### PR TITLE
[Reflection] Skip TestGenericMethodsInheritTheReflectedTypeOfTheirTemplate and TestInheritedEventAccessors xunit tests

### DIFF
--- a/src/System.Runtime/tests/System/Reflection/MemberInfoTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/MemberInfoTests.cs
@@ -44,7 +44,7 @@ namespace System.Reflection.Tests
             Assert.Null(p.SetMethod);
         }
 
-        [Fact]
+        [Fact(Skip="Mono issue #10276")]
         public static void TestGenericMethodsInheritTheReflectedTypeOfTheirTemplate()
         {
             Type t = typeof(Derived);
@@ -89,7 +89,7 @@ namespace System.Reflection.Tests
             Assert.Equal(t, setter.ReflectedType);
         }
 
-        [Fact]
+        [Fact(Skip="Mono issue #10277")]
         public static void TestInheritedEventAccessors()
         {
             Type t = typeof(Derived);


### PR DESCRIPTION
Relates to https://github.com/mono/mono/pull/9746

The issues:
- https://github.com/mono/mono/issues/10276
- https://github.com/mono/mono/issues/10277