### PR TITLE
Use  SkipOnTargetFramework instead of normal Skip to fix xunit issue

### DIFF
--- a/src/System.Runtime/tests/System/Reflection/MemberInfoTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Reflection/MemberInfoTests.netcoreapp.cs
@@ -337,7 +337,7 @@ namespace System.Reflection.Tests
             );
         }
 
-        [Fact(Skip="Mono issue #10159")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "Mono issue #10159")]
         [PlatformSpecific(TestPlatforms.Windows)]
         public static void HasSameMetadataDefinitionAs_CornerCase_CLSIDConstructor()
         {


### PR DESCRIPTION
Relates to https://github.com/mono/mono/pull/9746