### PR TITLE
[Reflection] Skip SetValueDirect_GetValueDirectRoundDataTest 

### DIFF
--- a/src/System.Reflection/tests/FieldInfoTests.cs
+++ b/src/System.Reflection/tests/FieldInfoTests.cs
@@ -533,7 +533,7 @@ namespace System.Reflection.Tests
             public object field;
         }
 
-        [Theory]
+        [Theory(Skip="Mono issue #10372")]
         [InlineData(222)]
         [InlineData("new value")]
         [InlineData('A')]


### PR DESCRIPTION
Relates to #https://github.com/mono/mono/pull/10370

The issue: https://github.com/mono/mono/issues/10372