### PR TITLE
[Reflection] Preparing EventInfo to import to MONO

### DIFF
--- a/src/Common/src/CoreLib/System/Reflection/EventInfo.cs
+++ b/src/Common/src/CoreLib/System/Reflection/EventInfo.cs
@@ -10,7 +10,7 @@ using EventRegistrationToken = System.Runtime.InteropServices.WindowsRuntime.Eve
 
 namespace System.Reflection
 {
-    public abstract class EventInfo : MemberInfo
+    public abstract partial class EventInfo : MemberInfo
     {
         protected EventInfo() { }
 
@@ -49,7 +49,12 @@ namespace System.Reflection
             get
             {
                 MethodInfo m = GetAddMethod(true);
+#if MONO
+                ParameterInfo[] p = m.GetParametersInternal ();
+#else
                 ParameterInfo[] p = m.GetParametersNoCopy();
+#endif
+
                 Type del = typeof(Delegate);
                 for (int i = 0; i < p.Length; i++)
                 {
@@ -61,6 +66,7 @@ namespace System.Reflection
             }
         }
 
+#if !MONO
         [DebuggerHidden]
         [DebuggerStepThrough]
         public virtual void AddEventHandler(object target, Delegate handler)
@@ -77,6 +83,7 @@ namespace System.Reflection
 
             addMethod.Invoke(target, new object[] { handler });
         }
+#endif
 
         [DebuggerHidden]
         [DebuggerStepThrough]


### PR DESCRIPTION
Relates to https://github.com/mono/mono/pull/10770.

The changes:
- made the class abstract; 
- updated EventHandlerType property to use `GetParametersInternal`; 
- excluded AddEventHandler property; existing Mono-implementation will be used due to some runtime dependencies.