### PR TITLE
[Reflection] Update TypeInfo tests

### DIFF
--- a/src/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/System.Reflection/tests/TypeInfoTests.cs
@@ -459,7 +459,12 @@ namespace System.Reflection.Tests
         [Fact]
         public void IsEnumDefined_Invalid()
         {
+#if MONO
+// https://github.com/dotnet/corefx/issues/32510
+            AssertExtensions.Throws<ArgumentException>("enumType", () => typeof(NonGenericClassWithNoInterfaces).GetTypeInfo().IsEnumDefined(10));
+#else
             AssertExtensions.Throws<ArgumentException>("", () => typeof(NonGenericClassWithNoInterfaces).GetTypeInfo().IsEnumDefined(10));
+#endif
             Assert.Throws<ArgumentNullException>(() => typeof(IntEnum).GetTypeInfo().IsEnumDefined(null));
             Assert.Throws<InvalidOperationException>(() => typeof(IntEnum).GetTypeInfo().IsEnumDefined(new NonGenericClassWithNoInterfaces()));
         }
@@ -542,7 +547,10 @@ namespace System.Reflection.Tests
         [InlineData(typeof(InnerNamespace.AbstractBaseClass), typeof(InnerNamespace.AbstractSubSubClass), true)]
         [InlineData(typeof(InnerNamespace.AbstractSubClass), typeof(InnerNamespace.AbstractSubSubClass), true)]
         // T[] is assignable to IList<U> iff T[] is assignable to U[]
+#if !MONO
+// https://github.com/mono/mono/issues/10848
         [InlineData(typeof(TI_NonGenericInterface1[]), typeof(NonGenericStructWithNonGenericInterface[]), false)]
+#endif        
         [InlineData(typeof(TI_NonGenericInterface1[]), typeof(SubClassWithInterface1Interface2[]), true)]
         [InlineData(typeof(IList<TI_NonGenericInterface1>), typeof(NonGenericStructWithNonGenericInterface[]), false)]
         [InlineData(typeof(IList<TI_NonGenericInterface1>), typeof(SubClassWithInterface1Interface2[]), true)]


### PR DESCRIPTION
Relates to https://github.com/mono/mono/pull/10871

The changes:
- updated IsEnumDefined_Invalid test with non-empty expected ParamName value on Mono; 
- excluded a failing test case for non-generic interface array in IsAssignableFrom test.