### PR TITLE
[Reflection] Resolve reflection tests namespace conflict

### DIFF
--- a/src/System.Runtime/tests/System/Reflection/ConstructorInfoTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/ConstructorInfoTests.cs
@@ -10,7 +10,11 @@ using Xunit;
 
 namespace System.Reflection.Tests
 {
+#if MONO
+    public static class RuntimeConstructorInfoTests
+#else
     public static class ConstructorInfoTests
+#endif
     {
         public static IEnumerable<object[]> Equality_TestData()
         {

--- a/src/System.Runtime/tests/System/Reflection/EventInfoTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/EventInfoTests.cs
@@ -9,7 +9,11 @@ using Xunit;
 
 namespace System.Reflection.Tests
 {
+#if MONO
+    public static class RuntimeEventInfoTests
+#else    
     public static class EventInfoTests
+#endif    
     {
         public static IEnumerable<object[]> Equality_TestData()
         {

--- a/src/System.Runtime/tests/System/Reflection/FieldInfoTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/FieldInfoTests.cs
@@ -9,7 +9,11 @@ using Xunit;
 
 namespace System.Reflection.Tests
 {
+#if MONO
+    public class RuntimeFieldInfoTests
+#else
     public class FieldInfoTests
+#endif
     {
         [Theory]
         [InlineData("nonstatic_strField", "nonstatic_strField", true)]

--- a/src/System.Runtime/tests/System/Reflection/FieldInfoTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/FieldInfoTests.cs
@@ -42,7 +42,11 @@ namespace System.Reflection.Tests
         // Helper method to get field from Type type
         private static FieldInfo GetField(string fieldName)
         {
+#if MONO
+            Type t = typeof(RuntimeFieldInfoTests);
+#else
             Type t = typeof(FieldInfoTests);
+#endif           
             TypeInfo ti = t.GetTypeInfo();
             IEnumerator<FieldInfo> alldefinedFields = ti.DeclaredFields.GetEnumerator();
             FieldInfo fi = null, found = null;

--- a/src/System.Runtime/tests/System/Reflection/MemberInfoTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/MemberInfoTests.cs
@@ -160,7 +160,11 @@ namespace System.Reflection.Tests
         [Fact]
         public void TestGetCustomAttributesData()
         {
+#if MONO
+            MemberInfo[] m = typeof(RuntimeMemberInfoTests).GetMember("SampleClass");
+#else
             MemberInfo[] m = typeof(MemberInfoTests).GetMember("SampleClass");
+#endif
             Assert.Equal(1, m.Count());
             foreach(CustomAttributeData cad in m[0].GetCustomAttributesData())
             {
@@ -182,7 +186,11 @@ namespace System.Reflection.Tests
         public static IEnumerable<object[]> EqualityOperator_TestData()
         {
             yield return new object[] { typeof(SampleClass) };
+#if MONO
+            yield return new object[] { new RuntimeMemberInfoTests().GetType() };
+#else
             yield return new object[] { new MemberInfoTests().GetType() };
+#endif
             yield return new object[] { typeof(int) };
             yield return new object[] { typeof(Dictionary<,>) };
         }

--- a/src/System.Runtime/tests/System/Reflection/MemberInfoTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/MemberInfoTests.cs
@@ -11,7 +11,11 @@ using Xunit;
 
 namespace System.Reflection.Tests
 {
+#if MONO
+    public class RuntimeMemberInfoTests
+#else
     public class MemberInfoTests
+#endif
     {
         [Fact]
         public static void TestReflectedType()

--- a/src/System.Runtime/tests/System/Reflection/ParameterInfoTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/ParameterInfoTests.cs
@@ -11,7 +11,11 @@ using Xunit;
 
 namespace System.Reflection.Tests
 {
+#if MONO
+    public static class RuntimeParameterInfoTests
+#else
     public static class ParameterInfoTests
+#endif
     {
         [Fact]
         public static void RawDefaultValue()

--- a/src/System.Runtime/tests/System/Reflection/ParameterInfoTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/ParameterInfoTests.cs
@@ -13,10 +13,13 @@ namespace System.Reflection.Tests
 {
 #if MONO
     public static class RuntimeParameterInfoTests
+    {
+        static Type testClassType = typeof (RuntimeParameterInfoTests);
 #else
     public static class ParameterInfoTests
-#endif
     {
+        static Type testClassType = typeof (ParameterInfoTests);
+#endif
         [Fact]
         public static void RawDefaultValue()
         {
@@ -30,7 +33,7 @@ namespace System.Reflection.Tests
         [Fact]
         public static void RawDefaultValueFromAttribute()
         {
-            MethodInfo m = GetMethod(typeof(ParameterInfoTests), "Foo2");
+            MethodInfo m = GetMethod(testClassType, "Foo2");
             ParameterInfo p = m.GetParameters()[0];
             object cooked = p.DefaultValue;
             object raw = p.RawDefaultValue;
@@ -42,7 +45,7 @@ namespace System.Reflection.Tests
         [Fact]
         public static void RawDefaultValue_MetadataTrumpsAttribute()
         {
-            MethodInfo m = GetMethod(typeof(ParameterInfoTests), "Foo3");
+            MethodInfo m = GetMethod(testClassType, "Foo3");
             ParameterInfo p = m.GetParameters()[0];
             object cooked = p.DefaultValue;
             object raw = p.RawDefaultValue;

--- a/src/System.Runtime/tests/System/Reflection/PropertyInfoTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/PropertyInfoTests.cs
@@ -8,7 +8,11 @@ using Xunit;
 
 namespace System.Reflection.Tests
 {
+#if MONO
+    public static class RuntimePropertyInfoTests
+#else
     public static class PropertyInfoTests
+#endif
     {
         [Fact]
         public static void GetRawConstantValueOnProperty()

--- a/src/System.Runtime/tests/System/Reflection/RuntimeReflectionExtensionsTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/RuntimeReflectionExtensionsTests.cs
@@ -9,7 +9,11 @@ using Xunit;
 
 namespace System.Reflection.Tests
 {
+#if MONO
+    public class RuntimeRuntimeReflectionExtensionsTests
+#else
     public class RuntimeReflectionExtensionsTests
+#endif
     {
         [Fact]
         public void GetMethodInfo()

--- a/src/System.Runtime/tests/System/Reflection/RuntimeReflectionExtensionsTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/RuntimeReflectionExtensionsTests.cs
@@ -18,7 +18,11 @@ namespace System.Reflection.Tests
         [Fact]
         public void GetMethodInfo()
         {
+#if MONO
+            Assert.Equal(typeof(RuntimeRuntimeReflectionExtensionsTests).GetMethod("GetMethodInfo"), ((Action)GetMethodInfo).GetMethodInfo());
+#else
             Assert.Equal(typeof(RuntimeReflectionExtensionsTests).GetMethod("GetMethodInfo"), ((Action)GetMethodInfo).GetMethodInfo());
+#endif
         }
 
         [Fact]

--- a/src/System.Runtime/tests/System/Reflection/TypeInfoTests.cs
+++ b/src/System.Runtime/tests/System/Reflection/TypeInfoTests.cs
@@ -121,7 +121,11 @@ namespace System.Reflection.Tests
         }
     }
 
+#if MONO
+    public class RuntimeTypeInfoTests
+#else
     public class TypeInfoTests
+#endif
     {
         public TypeInfo TestTypeInfo => typeof(TestType).GetTypeInfo();
 


### PR DESCRIPTION
It's workaround to avoid namespace conflict when we include xunit tests from both `external/corefx/src/System.Reflection/tests/` and `external/corefx/src/System.Runtime/tests/System/Reflection/` folders to corlib .source-file for xunit tests.