### PR TITLE
Reduce memory consumption of test by a factor of 4, sort of.

### DIFF
--- a/src/System.Threading.Tasks.Parallel/tests/ParallelForTests.cs
+++ b/src/System.Threading.Tasks.Parallel/tests/ParallelForTests.cs
@@ -516,7 +516,7 @@ namespace System.Threading.Tasks.Tests
         [InlineData(1)]
         [InlineData(1024)]
         [InlineData(1024 * 1024)]
-        [InlineData(1024 * 1024 * 16)]
+        [InlineData(1024 * 1024 * 4)]
         public static void RunSimpleParallelForeachAddTest_Array(int count)
         {
             // Just adds the contents of an auto-generated list inside a foreach loop. Hits the array code-path.


### PR DESCRIPTION
Perhaps GC is a factor and the memory consumption is not predictable.
Hopefully mitigates:

https://jenkins.mono-project.com/job/w/16341/testReport/junit/Test%20collection%20for%20System.Threading.Tasks.Tests/ParallelForTests/System_Threading_Tasks_Tests_ParallelForTests_RunSimpleParallelForeachAddTest_Array_count__16777216_/

```
Test collection for System.Threading.Tasks.Tests.ParallelForTests.System.Threading.Tasks.Tests.ParallelForTests.RunSimpleParallelForeachAddTest_Array(count: 16777216)

Failing for the past 1 build (Since Unstable#16341 )
Took 0 ms.
Error Message
System.OutOfMemoryException : Insufficient memory to continue the execution of the program.
Stacktrace
  at (wrapper alloc) System.Object.AllocVector(intptr,intptr)
  at System.Threading.Tasks.Tests.ParallelForTests.RunSimpleParallelForeachAddTest_Array (System.Int32 count) [0x00006] in D:\j\workspace\w\external\corefx\src\System.Threading.Tasks.Parallel\tests\ParallelForTests.cs:523
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in D:\j\workspace\w\mcs\class\corlib\System.Reflection\MonoMethod.cs:324
```

cut the 16777216 down by 4.