### PR TITLE
Prepare DateTime and TimeZone to be consumed by mono

### DIFF
--- a/src/Common/src/CoreLib/System/CurrentSystemTimeZone.cs
+++ b/src/Common/src/CoreLib/System/CurrentSystemTimeZone.cs
@@ -26,6 +26,9 @@ using System.Runtime.Versioning;
 
 namespace System
 {
+#if MONO
+    [Serializable]
+#endif
     [Obsolete("System.CurrentSystemTimeZone has been deprecated.  Please investigate the use of System.TimeZoneInfo.Local instead.")]
     internal partial class CurrentSystemTimeZone : TimeZone
     {

--- a/src/Common/src/CoreLib/System/DateTime.cs
+++ b/src/Common/src/CoreLib/System/DateTime.cs
@@ -52,7 +52,9 @@ namespace System
     // 
     [StructLayout(LayoutKind.Auto)]
     [Serializable]
+#if !MONO
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
+#endif
     public readonly partial struct DateTime : IComparable, IFormattable, IConvertible, IComparable<DateTime>, IEquatable<DateTime>, ISerializable, ISpanFormattable
     {
         // Number of 100ns ticks per time unit

--- a/src/Common/src/CoreLib/System/DateTimeOffset.cs
+++ b/src/Common/src/CoreLib/System/DateTimeOffset.cs
@@ -30,7 +30,9 @@ namespace System
 
     [StructLayout(LayoutKind.Auto)]
     [Serializable]
+#if !MONO
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
+#endif
     public struct DateTimeOffset : IComparable, IFormattable, IComparable<DateTimeOffset>, IEquatable<DateTimeOffset>, ISerializable, IDeserializationCallback, ISpanFormattable
     {
         // Constants

--- a/src/Common/src/CoreLib/System/Globalization/DateTimeFormat.cs
+++ b/src/Common/src/CoreLib/System/Globalization/DateTimeFormat.cs
@@ -461,7 +461,7 @@ namespace System
             }
             
             // This is a flag to indicate if we are format the dates using Hebrew calendar.
-            bool isHebrewCalendar = (cal.ID == CalendarId.HEBREW);
+            bool isHebrewCalendar = ((CalendarId)cal.ID == CalendarId.HEBREW);
             // This is a flag to indicate if we are formating hour/minute/second only.
             bool bTimeOnly = true;
 
@@ -657,7 +657,7 @@ namespace System
                         {
                             FormatDigits(result, year, tokenLen <= 2 ? tokenLen : 2);
                         }
-                        else if (cal.ID == CalendarId.HEBREW)
+                        else if ((CalendarId)cal.ID == CalendarId.HEBREW)
                         {
                             HebrewFormatDigits(result, year);
                         }
@@ -1085,7 +1085,7 @@ namespace System
                     // thrown when we try to get the Japanese year for Gregorian year 0001.
                     // Therefore, the workaround allows them to call ToString() for time of day from a DateTime by
                     // formatting as ISO 8601 format.
-                    switch (dtfi.Calendar.ID)
+                    switch ((CalendarId)dtfi.Calendar.ID)
                     {
                         case CalendarId.JAPAN:
                         case CalendarId.TAIWAN:

--- a/src/Common/src/CoreLib/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/Common/src/CoreLib/System/Globalization/DateTimeFormatInfo.cs
@@ -47,7 +47,9 @@ namespace System.Globalization
         NotInitialized = -1,
     }
 
-
+#if MONO
+    [Serializable]
+#endif
     public sealed class DateTimeFormatInfo : IFormatProvider, ICloneable
     {
         // cache for the invariant culture.
@@ -55,18 +57,22 @@ namespace System.Globalization
         private static volatile DateTimeFormatInfo s_invariantInfo;
 
         // an index which points to a record in Culture Data Table.
+        [NonSerialized]
         private CultureData _cultureData;
 
         // The culture name used to create this DTFI.
         private String _name = null;
 
         // The language name of the culture used to create this DTFI.
+        [NonSerialized]
         private String _langName = null;
 
         // CompareInfo usually used by the parser.
+        [NonSerialized]
         private CompareInfo _compareInfo = null;
 
         // Culture matches current DTFI. mainly used for string comparisons during parsing.
+        [NonSerialized]
         private CultureInfo _cultureInfo = null;
 
         //
@@ -310,10 +316,10 @@ namespace System.Globalization
             this.Calendar = cal;
         }
 
-        private void InitializeOverridableProperties(CultureData cultureData, CalendarId calendarId)
+        private void InitializeOverridableProperties(CultureData cultureData, int calendarId)
         {
             Debug.Assert(cultureData != null);
-            Debug.Assert(calendarId != CalendarId.UNINITIALIZED_VALUE, "[DateTimeFormatInfo.Populate] Expected initalized calendarId");
+            Debug.Assert(calendarId != (int)CalendarId.UNINITIALIZED_VALUE, "[DateTimeFormatInfo.Populate] Expected initalized calendarId");
 
             if (this.firstDayOfWeek == -1) { this.firstDayOfWeek = cultureData.IFIRSTDAYOFWEEK; }
             if (this.calendarWeekRule == -1) { this.calendarWeekRule = cultureData.IFIRSTWEEKOFYEAR; }
@@ -453,7 +459,7 @@ namespace System.Globalization
 
                 for (int i = 0; i < this.OptionalCalendars.Length; i++)
                 {
-                    if (this.OptionalCalendars[i] == value.ID)
+                    if (this.OptionalCalendars[i] == (CalendarId)value.ID)
                     {
                         // We can use this one, so do so.
 
@@ -531,7 +537,11 @@ namespace System.Globalization
             {
                 if (this.optionalCalendars == null)
                 {
+#if MONO
+                    this.optionalCalendars = _cultureData.GetCalendarIds();
+#else
                     this.optionalCalendars = _cultureData.CalendarIds;
+#endif
                 }
                 return (this.optionalCalendars);
             }
@@ -2110,7 +2120,7 @@ namespace System.Globalization
         {
             get
             {
-                switch (calendar.ID)
+                switch ((CalendarId)calendar.ID)
                 {
                     // Handle Japanese and Taiwan cases.
                     // If is y/yy, do not get (year % 100). "y" will print
@@ -2185,6 +2195,7 @@ namespace System.Globalization
         //
         // DateTimeFormatInfo tokenizer.  This is used by DateTime.Parse() to break input string into tokens.
         //
+        [NonSerialized]
         private TokenHashValue[] _dtfiTokenHash;
 
         private const int TOKEN_HASH_SIZE = 199;

--- a/src/Common/src/CoreLib/System/Globalization/DateTimeParse.cs
+++ b/src/Common/src/CoreLib/System/Globalization/DateTimeParse.cs
@@ -4455,7 +4455,7 @@ new DS[] { DS.ERROR, DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,  
             bool bTimeOnly = false;
             result.calendar = parseInfo.calendar;
 
-            if (parseInfo.calendar.ID == CalendarId.HEBREW)
+            if ((CalendarId)parseInfo.calendar.ID == CalendarId.HEBREW)
             {
                 parseInfo.parseNumberDelegate = m_hebrewNumberParser;
                 parseInfo.fCustomNumberParser = true;

--- a/src/Common/src/CoreLib/System/TimeZone.cs
+++ b/src/Common/src/CoreLib/System/TimeZone.cs
@@ -27,7 +27,7 @@ using System.Globalization;
 namespace System
 {
     [Obsolete("System.TimeZone has been deprecated.  Please investigate the use of System.TimeZoneInfo instead.")]
-    public abstract class TimeZone
+    public abstract partial class TimeZone
     {
         private static volatile TimeZone currentTimeZone = null;
 

--- a/src/Common/src/CoreLib/System/TimeZoneInfo.cs
+++ b/src/Common/src/CoreLib/System/TimeZoneInfo.cs
@@ -28,7 +28,9 @@ namespace System
     };
 
     [Serializable]
-#if !MONO
+#if MONO && MOBILE
+    [System.Runtime.CompilerServices.TypeForwardedFrom("System.Core, Version=2.0.5.0, Culture=Neutral, PublicKeyToken=7cec85d7bea7798e")]
+#else
     [System.Runtime.CompilerServices.TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
 #endif
     public sealed partial class TimeZoneInfo : IEquatable<TimeZoneInfo>, ISerializable, IDeserializationCallback

--- a/src/Common/src/CoreLib/System/TimeZoneInfo.cs
+++ b/src/Common/src/CoreLib/System/TimeZoneInfo.cs
@@ -28,7 +28,9 @@ namespace System
     };
 
     [Serializable]
+#if !MONO
     [System.Runtime.CompilerServices.TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
     public sealed partial class TimeZoneInfo : IEquatable<TimeZoneInfo>, ISerializable, IDeserializationCallback
     {
         private enum TimeZoneInfoResult


### PR DESCRIPTION
we are not planning to import underlying CultureInfo and CultureData so I had to apply a few changes (they don't brake corefx code)