### PR TITLE
[Reflection] Skip RawDefaultValueFromAttribute in ParameterInfoTests fixture

### DIFF
--- a/src/System.Reflection/tests/ParameterInfoTests.cs
+++ b/src/System.Reflection/tests/ParameterInfoTests.cs
@@ -97,7 +97,7 @@ namespace System.Reflection.Tests
             Assert.Equal<int>((int)raw, (int)BindingFlags.DeclaredOnly);
         }
 
-        [Fact]
+        [Fact(Skip="Mono issue #11051")]
         public void RawDefaultValueFromAttribute()
         {
             ParameterInfo p = GetParameterInfo(typeof(ParameterInfoMetadata), "Foo2", 0);


### PR DESCRIPTION
Issue https://github.com/mono/mono/issues/11051
Relates to https://github.com/mono/mono/pull/11221