### PR TITLE
Skip GetType reflection test in case when test method takes type full name in upper case and ignoring case flag.

### DIFF
--- a/src/System.Reflection/tests/GetTypeTests.cs
+++ b/src/System.Reflection/tests/GetTypeTests.cs
@@ -88,7 +88,10 @@ namespace System.Reflection.Tests
 
             Type type = typeof(MyNamespace1.MynAmespace3.Goo<int>);
             yield return new object[] { type.FullName, type };
+// see issue https://github.com/mono/mono/issues/11269
+#if !MONO
             yield return new object[] { type.FullName.ToUpper(), type };
+#endif
             yield return new object[] { type.FullName.ToLower(), type };
         }
 


### PR DESCRIPTION
Issue https://github.com/mono/mono/issues/11269.
Relates to https://github.com/mono/mono/pull/11221.
