### PR TITLE
Converted pal_(date)time, pal_sysctl, pal_runtimeextensions from C++ …

### DIFF
--- a/src/Native/Unix/System.Native/pal_datetime.c
+++ b/src/Native/Unix/System.Native/pal_datetime.c
@@ -22,19 +22,19 @@ static const int64_t TICKS_PER_MICROSECOND = 10; /* 1000 / 100 */
 // SystemNative_GetSystemTimeAsTicks return the system time as ticks (100 nanoseconds) 
 // since 00:00 01 January 1970 UTC (Unix epoch) 
 //
-extern "C" int64_t SystemNative_GetSystemTimeAsTicks()
+int64_t SystemNative_GetSystemTimeAsTicks()
 {
 #if HAVE_CLOCK_REALTIME
     struct timespec time;
     if (clock_gettime(CLOCK_REALTIME, &time) == 0)
     {
-        return static_cast<int64_t>(time.tv_sec) * TICKS_PER_SECOND + (time.tv_nsec / NANOSECONDS_PER_TICK); 
+        return (int64_t)(time.tv_sec) * TICKS_PER_SECOND + (time.tv_nsec / NANOSECONDS_PER_TICK); 
     }
 #else
     struct timeval time;
     if (gettimeofday(&time, NULL) == 0)
     {
-        return static_cast<int64_t>(time.tv_sec) * TICKS_PER_SECOND + (time.tv_usec * TICKS_PER_MICROSECOND); 
+        return (int64_t)(time.tv_sec) * TICKS_PER_SECOND + (time.tv_usec * TICKS_PER_MICROSECOND); 
     }
 #endif
     // in failure we return 00:00 01 January 1970 UTC (Unix epoch)

--- a/src/Native/Unix/System.Native/pal_runtimeextensions.c
+++ b/src/Native/Unix/System.Native/pal_runtimeextensions.c
@@ -7,12 +7,12 @@
 #include <stdio.h>
 #include <sys/utsname.h>
 
-extern "C" int32_t SystemNative_GetNodeName(char* version, int* capacity)
+int32_t SystemNative_GetNodeName(char* version, int* capacity)
 {
     struct utsname _utsname;
     if (uname(&_utsname) != -1)
     {
-        int r = snprintf(version, static_cast<size_t>(*capacity), "%s", _utsname.nodename);
+        int r = snprintf(version, (size_t)(*capacity), "%s", _utsname.nodename);
         if (r > *capacity)
         {
             *capacity = r + 1;

--- a/src/Native/Unix/System.Native/pal_sysctl.c
+++ b/src/Native/Unix/System.Native/pal_sysctl.c
@@ -15,18 +15,17 @@
 #include "pal_safecrt.h"
 
 #include <errno.h>
-#include <memory>
 
 #include <sys/types.h>
 #include <sys/sysctl.h>
 
-extern "C" int32_t SystemNative_Sysctl(int* name, unsigned int namelen, void* value, size_t* len)
+int32_t SystemNative_Sysctl(int* name, unsigned int namelen, void* value, size_t* len)
 {
-    void* newp = nullptr;
+    void* newp = NULL;
     size_t newlen = 0;
 
 #ifdef __linux__
-    return sysctl(name, static_cast<int>(namelen), value, len, newp, newlen);
+    return sysctl(name, (int)(namelen), value, len, newp, newlen);
 #else
     return sysctl(name, namelen, value, len, newp, newlen);
 #endif

--- a/src/Native/Unix/System.Native/pal_sysctl.h
+++ b/src/Native/Unix/System.Native/pal_sysctl.h
@@ -15,4 +15,3 @@ BEGIN_EXTERN_C
 DLLEXPORT int32_t SystemNative_Sysctl(int* name, unsigned int namelen, void* value, size_t* len);
 
 END_EXTERN_C
-

--- a/src/Native/Unix/System.Native/pal_time.c
+++ b/src/Native/Unix/System.Native/pal_time.c
@@ -20,25 +20,25 @@ enum
     SecondsToNanoSeconds = 1000000000 // 10^9
 };
 
-static void ConvertUTimBuf(const UTimBuf& pal, utimbuf& native)
+static void ConvertUTimBuf(const UTimBuf* pal, struct utimbuf* native)
 {
-    native.actime = static_cast<time_t>(pal.AcTime);
-    native.modtime = static_cast<time_t>(pal.ModTime);
+    native->actime = (time_t)(pal->AcTime);
+    native->modtime = (time_t)(pal->ModTime);
 }
 
-extern "C" int32_t SystemNative_UTime(const char* path, UTimBuf* times)
+int32_t SystemNative_UTime(const char* path, UTimBuf* times)
 {
-    assert(times != nullptr);
+    assert(times != NULL);
 
-    utimbuf temp;
-    ConvertUTimBuf(*times, temp);
+    struct utimbuf temp;
+    ConvertUTimBuf(times, &temp);
 
     int32_t result;
     while (CheckInterrupted(result = utime(path, &temp)));
     return result;
 }
 
-extern "C" int32_t SystemNative_GetTimestampResolution(uint64_t* resolution)
+int32_t SystemNative_GetTimestampResolution(uint64_t* resolution)
 {
     assert(resolution);
 
@@ -62,7 +62,7 @@ extern "C" int32_t SystemNative_GetTimestampResolution(uint64_t* resolution)
     mach_timebase_info_data_t mtid;
     if (mach_timebase_info(&mtid) == KERN_SUCCESS)
     {
-        *resolution = SecondsToNanoSeconds * (static_cast<uint64_t>(mtid.denom) / static_cast<uint64_t>(mtid.numer));
+        *resolution = SecondsToNanoSeconds * ((uint64_t)(mtid.denom) / (uint64_t)(mtid.numer));
         return 1;
     }
     else
@@ -78,7 +78,7 @@ extern "C" int32_t SystemNative_GetTimestampResolution(uint64_t* resolution)
 #endif
 }
 
-extern "C" int32_t SystemNative_GetTimestamp(uint64_t* timestamp)
+int32_t SystemNative_GetTimestamp(uint64_t* timestamp)
 {
     assert(timestamp);
 
@@ -87,7 +87,7 @@ extern "C" int32_t SystemNative_GetTimestamp(uint64_t* timestamp)
     int result = clock_gettime(CLOCK_MONOTONIC, &ts);
     assert(result == 0); // only possible errors are if MONOTONIC isn't supported or &ts is an invalid address
     (void)result; // suppress unused parameter warning in release builds
-    *timestamp = (static_cast<uint64_t>(ts.tv_sec) * SecondsToNanoSeconds) + static_cast<uint64_t>(ts.tv_nsec);
+    *timestamp = ((uint64_t)(ts.tv_sec) * SecondsToNanoSeconds) + (uint64_t)(ts.tv_nsec);
     return 1;
 
 #elif HAVE_MACH_ABSOLUTE_TIME
@@ -98,7 +98,7 @@ extern "C" int32_t SystemNative_GetTimestamp(uint64_t* timestamp)
     struct timeval tv;
     if (gettimeofday(&tv, NULL) == 0)
     {
-        *timestamp = (static_cast<uint64_t>(tv.tv_sec) * SecondsToMicroSeconds) + static_cast<uint64_t>(tv.tv_usec);
+        *timestamp = ((uint64_t)(tv.tv_sec) * SecondsToMicroSeconds) + (uint64_t)(tv.tv_usec);
         return 1;
     }
     else
@@ -110,7 +110,7 @@ extern "C" int32_t SystemNative_GetTimestamp(uint64_t* timestamp)
 #endif
 }
 
-extern "C" int32_t SystemNative_GetAbsoluteTime(uint64_t* timestamp)
+int32_t SystemNative_GetAbsoluteTime(uint64_t* timestamp)
 {
     assert(timestamp);
 
@@ -124,7 +124,7 @@ extern "C" int32_t SystemNative_GetAbsoluteTime(uint64_t* timestamp)
 #endif
 }
 
-extern "C" int32_t SystemNative_GetTimebaseInfo(uint32_t* numer, uint32_t* denom)
+int32_t SystemNative_GetTimebaseInfo(uint32_t* numer, uint32_t* denom)
 {
 #if  HAVE_MACH_TIMEBASE_INFO
     mach_timebase_info_data_t timebase;

--- a/src/Native/Unix/System.Native/pal_time.h
+++ b/src/Native/Unix/System.Native/pal_time.h
@@ -10,11 +10,11 @@ BEGIN_EXTERN_C
 
 #include "pal_types.h"
 
-struct UTimBuf
+typedef struct UTimBuf
 {
     int64_t AcTime;
     int64_t ModTime;
-};
+} UTimBuf;
 
 /**
  * Sets the last access and last modified time of a file


### PR DESCRIPTION
…to C (#30192)

* Converted pal_time, pal_datetime, pal_sysctl, pal_runtimeextensions from C++ to C

* Keep the EXTERN_C guards, as per PR feedback

Cf. https://github.com/dotnet/corefx/pull/30192#discussion_r194520428