### PR TITLE
Make all Encoding types serializable

### DIFF
--- a/src/Common/src/CoreLib/System/Text/DecoderBestFitFallback.cs
+++ b/src/Common/src/CoreLib/System/Text/DecoderBestFitFallback.cs
@@ -11,6 +11,9 @@ using System.Threading;
 
 namespace System.Text
 {
+#if MONO
+    [Serializable]
+#endif
     internal sealed class InternalDecoderBestFitFallback : DecoderFallback
     {
         // Our variables

--- a/src/Common/src/CoreLib/System/Text/EncoderBestFitFallback.cs
+++ b/src/Common/src/CoreLib/System/Text/EncoderBestFitFallback.cs
@@ -12,6 +12,9 @@ using System.Threading;
 
 namespace System.Text
 {
+#if MONO
+    [Serializable]
+#endif
     internal class InternalEncoderBestFitFallback : EncoderFallback
     {
         // Our variables

--- a/src/Common/src/CoreLib/System/Text/Latin1Encoding.cs
+++ b/src/Common/src/CoreLib/System/Text/Latin1Encoding.cs
@@ -29,6 +29,12 @@ namespace System.Text
         }
 
 #if MONO
+        internal Latin1Encoding(SerializationInfo info, StreamingContext context) :
+            base(Encoding.ISO_8859_1)
+        {
+            DeserializeEncoding(info, context);
+        }
+
         // ISerializable implementation, serialize it as a CodePageEncoding
         [System.Security.SecurityCritical]  // auto-generated_required
         void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)

--- a/src/Common/src/CoreLib/System/Text/UTF32Encoding.cs
+++ b/src/Common/src/CoreLib/System/Text/UTF32Encoding.cs
@@ -1183,6 +1183,9 @@ namespace System.Text
                    CodePage + (_emitUTF32ByteOrderMark ? 4 : 0) + (_bigEndian ? 8 : 0);
         }
 
+#if MONO
+        [Serializable]
+#endif
         private sealed class UTF32Decoder : DecoderNLS
         {
             // Need a place to store any extra bytes we may have picked up

--- a/src/Common/src/CoreLib/System/Text/UTF7Encoding.cs
+++ b/src/Common/src/CoreLib/System/Text/UTF7Encoding.cs
@@ -785,6 +785,9 @@ namespace System.Text
 
         // Of all the amazing things... This MUST be Decoder so that our com name
         // for System.Text.Decoder doesn't change
+#if MONO
+        [Serializable]
+#endif
         private sealed class Decoder : DecoderNLS
         {
             /*private*/
@@ -822,6 +825,9 @@ namespace System.Text
 
         // Of all the amazing things... This MUST be Encoder so that our com name
         // for System.Text.Encoder doesn't change
+#if MONO
+        [Serializable]
+#endif
         private sealed class Encoder : EncoderNLS
         {
             /*private*/
@@ -854,6 +860,9 @@ namespace System.Text
 
         // Preexisting UTF7 behavior for bad bytes was just to spit out the byte as the next char
         // and turn off base64 mode if it was in that mode.  We still exit the mode, but now we fallback.
+#if MONO
+        [Serializable]
+#endif
         private sealed class DecoderUTF7Fallback : DecoderFallback
         {
             // Construction.  Default replacement fallback uses no best fit and ? replacement string

--- a/src/Common/src/CoreLib/System/Text/UTF8Encoding.cs
+++ b/src/Common/src/CoreLib/System/Text/UTF8Encoding.cs
@@ -2536,6 +2536,9 @@ namespace System.Text
                    UTF8_CODEPAGE + (_emitUTF8Identifier ? 1 : 0);
         }
 
+#if MONO
+        [Serializable]
+#endif
         private sealed class UTF8Encoder : EncoderNLS
         {
             // We must save a high surrogate value until the next call, looking
@@ -2565,6 +2568,9 @@ namespace System.Text
             }
         }
 
+#if MONO
+        [Serializable]
+#endif
         private sealed class UTF8Decoder : DecoderNLS
         {
             // We'll need to remember the previous information. See the comments around definition

--- a/src/Common/src/CoreLib/System/Text/UnicodeEncoding.cs
+++ b/src/Common/src/CoreLib/System/Text/UnicodeEncoding.cs
@@ -1924,6 +1924,9 @@ namespace System.Text
                    (byteOrderMark ? 4 : 0) + (bigEndian ? 8 : 0);
         }
 
+#if MONO
+        [Serializable]
+#endif
         private sealed class Decoder : System.Text.DecoderNLS
         {
             internal int lastByte = -1;


### PR DESCRIPTION
Did not notice these types because they are not public thus not part of the public API (api-diff).

Tested via:
```csharp
foreach (var encoding in Encoding.GetEncodings().Select(e => Encoding.GetEncoding(e.Name)))
{
	var serializer = new BinaryFormatter();
	using (var ms = new MemoryStream())
	{
		serializer.Serialize(ms, encoding);
		ms.Position = 0;
		var clone = (Encoding)serializer.Deserialize(ms);
		Assert.Equals(encoding, clone);
	}
}
```
in mono
https://github.com/mono/mono/issues/11529