### PR TITLE
Re-initialize DirectoryInfo.Name after a MoveTo() operation

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
@@ -212,7 +212,7 @@ namespace System.IO
 
             Init(originalPath: destDirName,
                  fullPath: destinationWithSeparator,
-                 fileName: _name,
+                 fileName: null,
                  isNormalized: true);
 
             // Flush any cached information about the directory.

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/MoveTo.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/MoveTo.cs
@@ -28,19 +28,23 @@ namespace System.IO.Tests
         public void DirectoryPathUpdatesOnMove()
         {
             //NOTE: MoveTo adds a trailing separator character to the FullName of a DirectoryInfo
+            string DestName1 = GetTestFileName();
+            string DestName2 = GetTestFileName();
             string testDirSource = Path.Combine(TestDirectory, GetTestFileName());
-            string testDirDest1 = Path.Combine(TestDirectory, GetTestFileName());
-            string testDirDest2 = Path.Combine(TestDirectory, GetTestFileName());
+            string testDirDest1 = Path.Combine(TestDirectory, DestName1);
+            string testDirDest2 = Path.Combine(TestDirectory, DestName2);
 
             DirectoryInfo sourceDir = Directory.CreateDirectory(testDirSource);
             Move(sourceDir, testDirDest1);
             Assert.True(Directory.Exists(testDirDest1));
             Assert.False(Directory.Exists(testDirSource));
             Assert.Equal(testDirDest1 + Path.DirectorySeparatorChar, sourceDir.FullName);
+            Assert.Equal(DestName1, sourceDir.Name);
 
             Move(sourceDir, testDirDest2);
             Assert.True(Directory.Exists(testDirDest2));
             Assert.Equal(testDirDest2 + Path.DirectorySeparatorChar, sourceDir.FullName);
+            Assert.Equal(DestName2, sourceDir.Name);
         }
 
         #endregion


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/33490

Already accepted upstream: https://github.com/dotnet/corefx/pull/33496

Required for https://github.com/mono/mono/pull/11342