### PR TITLE
[reflection] Changes in Type.cs, TypeTests.cs and TypeTests.netcoreapp.cs

### DIFF
--- a/src/Common/src/CoreLib/System/Type.cs
+++ b/src/Common/src/CoreLib/System/Type.cs
@@ -23,7 +23,11 @@ namespace System
         public abstract string FullName { get; }
 
         public abstract Assembly Assembly { get; }
+#if MONO
+        public override abstract Module Module { get; }
+#else
         public abstract new Module Module { get; }
+#endif
 
         public bool IsNested => DeclaringType != null;
         public override Type DeclaringType => null;
@@ -100,7 +104,11 @@ namespace System
         public bool IsCOMObject => IsCOMObjectImpl();
         protected abstract bool IsCOMObjectImpl();
         public bool IsContextful => IsContextfulImpl();
+#if MONO
+        protected virtual bool IsContextfulImpl() => typeof(ContextBoundObject).IsAssignableFrom(this);
+#else
         protected virtual bool IsContextfulImpl() => false;
+#endif
 
         public virtual bool IsCollectible => true;
 

--- a/src/Common/src/CoreLib/System/Type.cs
+++ b/src/Common/src/CoreLib/System/Type.cs
@@ -23,11 +23,7 @@ namespace System
         public abstract string FullName { get; }
 
         public abstract Assembly Assembly { get; }
-#if MONO
-        public override abstract Module Module { get; }
-#else
         public abstract new Module Module { get; }
-#endif
 
         public bool IsNested => DeclaringType != null;
         public override Type DeclaringType => null;

--- a/src/System.Runtime/tests/System/TypeTests.cs
+++ b/src/System.Runtime/tests/System/TypeTests.cs
@@ -242,7 +242,9 @@ namespace System.Tests
         [InlineData("system.nullable`1[system.int32]", typeof(TypeLoadException), false)]
         [InlineData("System.NonExistingType", typeof(TypeLoadException), false)]
         [InlineData("", typeof(TypeLoadException), false)]
+#if !MONO // MONO issue #11684
         [InlineData("System.Int32[,*,]", typeof(ArgumentException), false)]
+#endif
         [InlineData("Outside`2", typeof(TypeLoadException), false)]
         [InlineData("Outside`1[System.Boolean, System.Int32]", typeof(ArgumentException), true)]
         public static void GetTypeByName_Invalid(string typeName, Type expectedException, bool alwaysThrowsException)
@@ -317,12 +319,16 @@ namespace System.Tests
         static string testtype = "System.Collections.Generic.Dictionary`2[[Program, Foo], [Program, Foo]]";
 
         private static Func<AssemblyName, Assembly> assemblyloader = (aName) => aName.Name == "TestLoadAssembly" ?
+#if MONO
+                           Assembly.LoadFrom(@"TestLoadAssembly.dll") :
+#else
                            Assembly.LoadFrom(@".\TestLoadAssembly.dll") :
+#endif
                            null;
         private static Func<Assembly, String, Boolean, Type> typeloader = (assem, name, ignore) => assem == null ?
                              Type.GetType(name, false, ignore) :
                                  assem.GetType(name, false, ignore);
-        [Fact]
+        [Fact(Skip="Mono issue #11692")]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Assembly.LoadFrom() is not supported on UapAot")]
         public static void GetTypeByName()
         {
@@ -397,6 +403,7 @@ namespace System.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono)]
         public static void IsContextful()
         {
             Assert.True(!typeof(TypeTestsExtended).IsContextful);

--- a/src/System.Runtime/tests/System/TypeTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/TypeTests.netcoreapp.cs
@@ -226,7 +226,9 @@ namespace System.Tests
                 yield return new object[] { typeof(ByRefLikeStruct), true };
                 yield return new object[] { typeof(RegularStruct), false };
                 yield return new object[] { typeof(object), false };
+#if !MONO // MONO issue #11693
                 yield return new object[] { typeof(Span<int>).MakeByRefType(), false };
+#endif                
                 yield return new object[] { typeof(Span<int>).MakePointerType(), false };
                 yield return new object[] { theT, false };
                 yield return new object[] { typeof(int[]), false };


### PR DESCRIPTION
Relates to https://github.com/mono/mono/pull/11665.

The changes:
- moved IsContextfulImpl method from referencesource to fix `MonoTests.System.Reflection.Emit.TypeBuilderTest.TestIsContextful`;
- changed Module property from `new` to `override` to avoid API change.
- disabled some test cases in TypeTests.cs and TypeTests.netcoreapp.cs (https://github.com/mono/mono/issues/11684, https://github.com/mono/mono/issues/11692, https://github.com/mono/mono/issues/11693)