### PR TITLE
Avoid test data conflict between TypeTests and ModuleTests

### DIFF
--- a/src/System.Reflection/tests/ModuleTests.cs
+++ b/src/System.Reflection/tests/ModuleTests.cs
@@ -28,7 +28,7 @@ namespace System.Reflection.Tests
             Assert.Equal(typeInfo.Assembly, module.Assembly);
         }
 
-        [Theory(Skip="Mono issue #11569")]
+        [Theory]
         [InlineData(typeof(Attr), 77, "AttrSimple")]
         [InlineData(typeof(Int32Attr), 77, "Int32AttrSimple")]
         [InlineData(typeof(Int64Attr), (long)77, "Int64AttrSimple")]
@@ -64,11 +64,11 @@ namespace System.Reflection.Tests
         [InlineData("System.Nullable`1[System.Int32]", typeof(int?))]
         [InlineData("System.Int32*", typeof(int*))]
         [InlineData("System.Int32**", typeof(int**))]
-        [InlineData("Outside`1", typeof(Outside<>))]
-        [InlineData("Outside`1+Inside`1", typeof(Outside<>.Inside<>))]
-        [InlineData("Outside[]", typeof(Outside[]))]
-        [InlineData("Outside[,,]", typeof(Outside[,,]))]
-        [InlineData("Outside[][]", typeof(Outside[][]))]        
+        [InlineData("OutsideModuleTest`1", typeof(OutsideModuleTest<>))]
+        [InlineData("OutsideModuleTest`1+InsideModuleTest`1", typeof(OutsideModuleTest<>.InsideModuleTest<>))]
+        [InlineData("OutsideModuleTest[]", typeof(OutsideModuleTest[]))]
+        [InlineData("OutsideModuleTest[,,]", typeof(OutsideModuleTest[,,]))]
+        [InlineData("OutsideModuleTest[][]", typeof(OutsideModuleTest[][]))]        
         public void GetType(string className, Type expectedType)
         {
             Module module = expectedType.GetTypeInfo().Module;
@@ -79,15 +79,75 @@ namespace System.Reflection.Tests
             Assert.Null(module.GetType(className.ToLower(), false, false));
             Assert.Throws<TypeLoadException>(() => module.GetType(className.ToLower(), true, false));
         }
+
+        [Fact]
+        public void FilterTypeName_DelegateFiltersExpectedTypes()
+        {
+            Assert.NotNull(Module.FilterTypeName);
+            Assert.Same(Module.FilterTypeName, Module.FilterTypeName);
+            Assert.NotSame(Module.FilterTypeName, Module.FilterTypeNameIgnoreCase);
+
+            Assert.Throws<InvalidFilterCriteriaException>(() => Module.FilterTypeName(GetType(), null));
+            Assert.Throws<InvalidFilterCriteriaException>(() => Module.FilterTypeName(GetType(), new object()));
+
+            Assert.Empty(typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeName, "out*"));
+            Assert.Equal(2, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeName, "OutsideMod*").Length);
+            Assert.Empty(typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeName, "outsidemoduletest"));
+            Assert.Equal(1, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeName, "OutsideModuleTest").Length);
+            Assert.Equal(1, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeName, "InsideModuleTest").Length);
+
+            Assert.True(Module.FilterTypeName(typeof(string), "String"));
+            Assert.True(Module.FilterTypeName(typeof(string), "*"));
+            Assert.True(Module.FilterTypeName(typeof(string), "S*"));
+            Assert.True(Module.FilterTypeName(typeof(string), "Strin*"));
+            Assert.True(Module.FilterTypeName(typeof(string), "String"));
+            Assert.True(Module.FilterTypeName(typeof(string), "String*"));
+
+            Assert.False(Module.FilterTypeName(typeof(string), ""));
+            Assert.False(Module.FilterTypeName(typeof(string), "S"));
+            Assert.False(Module.FilterTypeName(typeof(string), " String"));
+            Assert.False(Module.FilterTypeName(typeof(string), "String "));
+            Assert.False(Module.FilterTypeName(typeof(string), "Strings"));
+        }
+
+        [Fact]
+        public void FilterTypeNameIgnoreCase_DelegateFiltersExpectedTypes()
+        {
+            Assert.NotNull(Module.FilterTypeNameIgnoreCase);
+            Assert.Same(Module.FilterTypeNameIgnoreCase, Module.FilterTypeNameIgnoreCase);
+            Assert.NotSame(Module.FilterTypeNameIgnoreCase, Module.FilterTypeName);
+
+            Assert.Throws<InvalidFilterCriteriaException>(() => Module.FilterTypeName(GetType(), null));
+            Assert.Throws<InvalidFilterCriteriaException>(() => Module.FilterTypeName(GetType(), new object()));
+
+            Assert.Equal(2, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeNameIgnoreCase, "outsidemod*").Length);
+            Assert.Equal(2, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeNameIgnoreCase, "Outsidemod*").Length);
+            Assert.Equal(1, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeNameIgnoreCase, "ouTsidemoduLeTest").Length);
+            Assert.Equal(1, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeNameIgnoreCase, "OutsideModuleTest").Length);
+            Assert.Equal(1, typeof(ModuleTest).GetTypeInfo().Module.FindTypes(Module.FilterTypeNameIgnoreCase, "insiDemoduLeTest").Length);
+
+            Assert.True(Module.FilterTypeNameIgnoreCase(typeof(string), "string"));
+            Assert.True(Module.FilterTypeNameIgnoreCase(typeof(string), "*"));
+            Assert.True(Module.FilterTypeNameIgnoreCase(typeof(string), "s*"));
+            Assert.True(Module.FilterTypeNameIgnoreCase(typeof(string), "stRIn*"));
+            Assert.True(Module.FilterTypeNameIgnoreCase(typeof(string), "sTrInG"));
+            Assert.True(Module.FilterTypeNameIgnoreCase(typeof(string), "STRING*"));
+
+            Assert.False(Module.FilterTypeNameIgnoreCase(typeof(string), ""));
+            Assert.False(Module.FilterTypeNameIgnoreCase(typeof(string), "s"));
+            Assert.False(Module.FilterTypeNameIgnoreCase(typeof(string), " string"));
+            Assert.False(Module.FilterTypeNameIgnoreCase(typeof(string), "string "));
+            Assert.False(Module.FilterTypeNameIgnoreCase(typeof(string), "strings"));
+        }
     }
 }
 
-public class Outside
+public class OutsideModuleTest
 {
-    public class Inside { }
+    public class InsideModuleTest { }
 }
 
-public class Outside<T>
+public class OutsideModuleTest<T>
 {
-    public class Inside<U> { }
+    public class InsideModuleTest<U> { }
 }

--- a/src/System.Reflection/tests/TypeInfoTests.netcoreapp.cs
+++ b/src/System.Reflection/tests/TypeInfoTests.netcoreapp.cs
@@ -32,12 +32,12 @@ namespace System.Reflection.Tests
             yield return new object[] { typeof(int).MakeArrayType(1), false };
             yield return new object[] { typeof(int).MakeArrayType().MakeArrayType(), true };
             yield return new object[] { typeof(int).MakeArrayType(2), false };
-            yield return new object[] { typeof(Outside<int>.Inside<string>), false };
-            yield return new object[] { typeof(Outside<int>.Inside<string>[]), true };
-            yield return new object[] { typeof(Outside<int>.Inside<string>[,]), false };
+            yield return new object[] { typeof(OutsideTypeInfoNetcoreTests<int>.InsideTypeInfoNetcoreTests<string>), false };
+            yield return new object[] { typeof(OutsideTypeInfoNetcoreTests<int>.InsideTypeInfoNetcoreTests<string>[]), true };
+            yield return new object[] { typeof(OutsideTypeInfoNetcoreTests<int>.InsideTypeInfoNetcoreTests<string>[,]), false };
             if (PlatformDetection.IsNonZeroLowerBoundArraySupported)
             {
-                yield return new object[] { Array.CreateInstance(typeof(Outside<int>.Inside<string>), new[] { 2 }, new[] { -1 }).GetType(), false };
+                yield return new object[] { Array.CreateInstance(typeof(OutsideTypeInfoNetcoreTests<int>.InsideTypeInfoNetcoreTests<string>), new[] { 2 }, new[] { -1 }).GetType(), false };
             }
         }
 
@@ -47,4 +47,14 @@ namespace System.Reflection.Tests
             Assert.Equal(expected, type.GetTypeInfo().IsSZArray);
         }
     }
+
+    public class OutsideTypeInfoNetcoreTests
+    {
+        public class InsideTypeInfoNetcoreTests { }
+    }
+
+    public class OutsideTypeInfoNetcoreTests<T>
+    {
+        public class InsideTypeInfoNetcoreTests<U> { }
+    }    
 }

--- a/src/System.Runtime/tests/System/TypeTests.cs
+++ b/src/System.Runtime/tests/System/TypeTests.cs
@@ -8,9 +8,6 @@ using System.IO;
 using System.Reflection;
 using Xunit;
 
-// These classes conflict with ones from System.Reflection/tests/ModuleTests.cs
-// within single test assembly on MONO.
-#if !MONO
 internal class Outside
 {
     public class Inside { }
@@ -20,7 +17,6 @@ internal class Outside<T>
 {
     public class Inside<U> { }
 }
-#endif
 
 namespace System.Tests
 {

--- a/src/System.Runtime/tests/System/TypeTests.cs
+++ b/src/System.Runtime/tests/System/TypeTests.cs
@@ -8,6 +8,9 @@ using System.IO;
 using System.Reflection;
 using Xunit;
 
+// These classes conflict with ones from System.Reflection/tests/ModuleTests.cs
+// within single test assembly on MONO.
+#if !MONO
 internal class Outside
 {
     public class Inside { }
@@ -17,6 +20,7 @@ internal class Outside<T>
 {
     public class Inside<U> { }
 }
+#endif
 
 namespace System.Tests
 {


### PR DESCRIPTION
Relates to https://github.com/mono/mono/pull/11665

