### PR TITLE
Fix binary compatibility with old mono for Encodings. 

### DIFF
--- a/src/Common/src/CoreLib/System/Text/DecoderReplacementFallback.cs
+++ b/src/Common/src/CoreLib/System/Text/DecoderReplacementFallback.cs
@@ -3,13 +3,16 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Runtime.Serialization;
 
 namespace System.Text
 {
 #if MONO
     [System.Serializable]
-#endif
+    public sealed class DecoderReplacementFallback : DecoderFallback, ISerializable
+#else
     public sealed class DecoderReplacementFallback : DecoderFallback
+#endif
     {
         // Our variables
         private String _strDefault;
@@ -18,6 +21,12 @@ namespace System.Text
         public DecoderReplacementFallback() : this("?")
         {
         }
+
+#if MONO
+        internal DecoderReplacementFallback(SerializationInfo info, StreamingContext context) => _strDefault = info.GetString("strDefault");
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context) => info.AddValue("strDefault", _strDefault);
+#endif
 
         public DecoderReplacementFallback(String replacement)
         {

--- a/src/Common/src/CoreLib/System/Text/DecoderReplacementFallback.cs
+++ b/src/Common/src/CoreLib/System/Text/DecoderReplacementFallback.cs
@@ -25,7 +25,7 @@ namespace System.Text
 #if MONO
         internal DecoderReplacementFallback(SerializationInfo info, StreamingContext context) => _strDefault = info.GetString("strDefault");
 
-        public void GetObjectData(SerializationInfo info, StreamingContext context) => info.AddValue("strDefault", _strDefault);
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) => info.AddValue("strDefault", _strDefault);
 #endif
 
         public DecoderReplacementFallback(String replacement)

--- a/src/Common/src/CoreLib/System/Text/EncoderReplacementFallback.cs
+++ b/src/Common/src/CoreLib/System/Text/EncoderReplacementFallback.cs
@@ -5,13 +5,16 @@
 using System;
 using System.Runtime;
 using System.Diagnostics;
+using System.Runtime.Serialization;
 
 namespace System.Text
 {
 #if MONO
-    [Serializable]
-#endif
+    [System.Serializable]
+    public sealed class EncoderReplacementFallback : EncoderFallback, ISerializable
+#else
     public sealed class EncoderReplacementFallback : EncoderFallback
+#endif
     {
         // Our variables
         private String _strDefault;
@@ -20,6 +23,12 @@ namespace System.Text
         public EncoderReplacementFallback() : this("?")
         {
         }
+
+#if MONO
+        internal EncoderReplacementFallback(SerializationInfo info, StreamingContext context) =>_strDefault = info.GetString("strDefault");
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context) => info.AddValue("strDefault", _strDefault);
+#endif
 
         public EncoderReplacementFallback(String replacement)
         {

--- a/src/Common/src/CoreLib/System/Text/EncoderReplacementFallback.cs
+++ b/src/Common/src/CoreLib/System/Text/EncoderReplacementFallback.cs
@@ -10,7 +10,7 @@ using System.Runtime.Serialization;
 namespace System.Text
 {
 #if MONO
-    [System.Serializable]
+    [Serializable]
     public sealed class EncoderReplacementFallback : EncoderFallback, ISerializable
 #else
     public sealed class EncoderReplacementFallback : EncoderFallback
@@ -27,7 +27,7 @@ namespace System.Text
 #if MONO
         internal EncoderReplacementFallback(SerializationInfo info, StreamingContext context) =>_strDefault = info.GetString("strDefault");
 
-        public void GetObjectData(SerializationInfo info, StreamingContext context) => info.AddValue("strDefault", _strDefault);
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) => info.AddValue("strDefault", _strDefault);
 #endif
 
         public EncoderReplacementFallback(String replacement)

--- a/src/Common/src/System/Drawing/ColorTable.cs
+++ b/src/Common/src/System/Drawing/ColorTable.cs
@@ -16,6 +16,9 @@ namespace System.Drawing
         {
             var dict = new Dictionary<string, Color>(StringComparer.OrdinalIgnoreCase);
             FillConstants(dict, typeof(Color));
+#if MONO
+            FillConstants(dict, typeof(SystemColors));
+#endif
             return dict;
         }
 


### PR DESCRIPTION
Needed for https://github.com/mono/mono/issues/11663
In order to reduce changes-diff I decided to fix the issue using `ISerializable` impl instead of renamings.

SystemColors changes is required for us (the change is upstreamed: https://github.com/dotnet/corefx/pull/33520).