### PR TITLE
Fix TestAssembly.dll path

### DIFF
--- a/src/System.Runtime/tests/System/TypeTests.cs
+++ b/src/System.Runtime/tests/System/TypeTests.cs
@@ -318,7 +318,7 @@ namespace System.Tests
 
         private static Func<AssemblyName, Assembly> assemblyloader = (aName) => aName.Name == "TestLoadAssembly" ?
 #if MONO
-                           Assembly.LoadFrom(@"TestLoadAssembly.dll") :
+                           Assembly.LoadFrom(Path.Combine(Path.GetDirectoryName(typeof(TypeTestsExtended).Assembly.Location), "TestLoadAssembly.dll")) :
 #else
                            Assembly.LoadFrom(@".\TestLoadAssembly.dll") :
 #endif


### PR DESCRIPTION
For some TypeTestsExtended tests we need to load TestAssembly.dll not from 
current directory but from profile-specific one (`mcs/class/lib/<PROFILE>/tests`).

Relates to https://github.com/mono/mono/pull/11665