### PR TITLE
Use CryptoConfig.MapNameToOid instead of OID.FromFriendlyName

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSAPKCS1SignatureDeformatter.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSAPKCS1SignatureDeformatter.cs
@@ -30,15 +30,13 @@ namespace System.Security.Cryptography
 
         public override void SetHashAlgorithm(string strName)
         {
-            try
+            // Verify the name
+            if (CryptoConfig.MapNameToOID(strName) != null)
             {
-                // Verify the name
-                Oid.FromFriendlyName(strName, OidGroup.HashAlgorithm);
-
                 // Uppercase known names as required for BCrypt
                 _algName = HashAlgorithmNames.ToUpper(strName);
             }
-            catch (CryptographicException)
+            else
             {
                 // For desktop compat, exception is deferred until VerifySignature
                 _algName = null;

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSAPKCS1SignatureFormatter.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSAPKCS1SignatureFormatter.cs
@@ -31,15 +31,13 @@ namespace System.Security.Cryptography
 
         public override void SetHashAlgorithm(string strName)
         {
-            try
+            // Verify the name
+            if (CryptoConfig.MapNameToOID(strName) != null)
             {
-                // Verify the name
-                Oid.FromFriendlyName(strName, OidGroup.HashAlgorithm);
-
                 // Uppercase known names as required for BCrypt
                 _algName = HashAlgorithmNames.ToUpper(strName);
             }
-            catch (CryptographicException)
+            else
             {
                 // For desktop compat, exception is deferred until VerifySignature
                 _algName = null;


### PR DESCRIPTION
Cherry-picking upstream https://github.com/dotnet/corefx/pull/31568.

This is functionally the same, but helps Mono with a layering problem.

(cherry picked from commit 58a310782b805df19a3939b12544c39296db5ed3)