### PR TITLE
Encoding: Improve serialization 

### DIFF
--- a/src/Common/src/CoreLib/System/Text/DecoderReplacementFallback.cs
+++ b/src/Common/src/CoreLib/System/Text/DecoderReplacementFallback.cs
@@ -23,7 +23,11 @@ namespace System.Text
         }
 
 #if MONO
-        internal DecoderReplacementFallback(SerializationInfo info, StreamingContext context) => _strDefault = info.GetString("strDefault");
+        internal DecoderReplacementFallback(SerializationInfo info, StreamingContext context)
+        {
+            try { _strDefault = info.GetString("strDefault"); } // for old mono and .NET 4.x
+            catch { _strDefault = info.GetString("_strDefault"); }
+        }
 
         void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) => info.AddValue("strDefault", _strDefault);
 #endif

--- a/src/Common/src/CoreLib/System/Text/EncoderReplacementFallback.cs
+++ b/src/Common/src/CoreLib/System/Text/EncoderReplacementFallback.cs
@@ -25,7 +25,11 @@ namespace System.Text
         }
 
 #if MONO
-        internal EncoderReplacementFallback(SerializationInfo info, StreamingContext context) =>_strDefault = info.GetString("strDefault");
+        internal EncoderReplacementFallback(SerializationInfo info, StreamingContext context)
+        {
+            try { _strDefault = info.GetString("strDefault"); } // for old mono and .NET 4.x
+            catch { _strDefault = info.GetString("_strDefault"); }
+        }
 
         void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) => info.AddValue("strDefault", _strDefault);
 #endif


### PR DESCRIPTION
A small addition to https://github.com/mono/corefx/pull/204
There is a small chance of a failure if users serialized their encodings using some recent mono and probably want to be able to deserialize it with mono vNext.
