### PR TITLE
Forward HashAlgorithm.Create() to a new CryptoConfigForwarder.CreateDefaultHashAlgorithm().

### DIFF
--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoConfigForwarder.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoConfigForwarder.cs
@@ -29,5 +29,8 @@ namespace System.Security.Cryptography
         }
 
         internal static object CreateFromName(string name) => s_createFromName(name);
+
+        internal static HashAlgorithm CreateDefaultHashAlgorithm() =>
+            throw new PlatformNotSupportedException(SR.Cryptography_DefaultAlgorithm_NotSupported);
     }
 }

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/HashAlgorithm.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/HashAlgorithm.cs
@@ -17,7 +17,7 @@ namespace System.Security.Cryptography
         protected HashAlgorithm() { }
 
         public static HashAlgorithm Create() =>
-            throw new PlatformNotSupportedException(SR.Cryptography_DefaultAlgorithm_NotSupported);
+            CryptoConfigForwarder.CreateDefaultHashAlgorithm();
 
         public static HashAlgorithm Create(string hashName) =>
             (HashAlgorithm)CryptoConfigForwarder.CreateFromName(hashName);


### PR DESCRIPTION
Applying upstream https://github.com/dotnet/corefx/pull/33705.

Forward HashAlgorithm.Create() to a new CryptoConfigForwarder.CreateDefaultHashAlgorithm().

In Mono, `HashAlgorithm.Create()` returns a default algorithm instead of throwing PNSE;
this allows us use a custom version of `CryptoConfigForwarder` to keep compatibility.