### PR TITLE
"Imperial Red": Mono-specific changes for HttpClient

### DIFF
--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
@@ -39,6 +39,10 @@ namespace System
         public static bool IsNotWinRTSupported => !IsWinRTSupported;
         public static bool IsNotMacOsHighSierraOrHigher => !IsMacOsHighSierraOrHigher;
 
+        public static bool IsSsl2AndSsl3Supported => false;
+        public static bool SupportsX509Chain => true;
+        public static bool SupportsCertRevocation => true;
+
         public static bool IsDomainJoinedMachine => !Environment.MachineName.Equals(Environment.UserDomainName, StringComparison.OrdinalIgnoreCase);
 
         // Officially, .Net Native only supports processes running in an AppContainer. However, the majority of tests still work fine

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -421,7 +421,13 @@ namespace System.Net.Http
                 return (null, tunnelResponse);
             }
 
+#if __MonoCS__
+            var result = await tunnelResponse.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            return (result, null);
+#else
             return (await tunnelResponse.Content.ReadAsStreamAsync().ConfigureAwait(false), null);
+#endif
+
         }
 
         /// <summary>Enqueues a waiter to the waiters list.</summary>
@@ -598,7 +604,13 @@ namespace System.Net.Http
                             try
                             {
                                 // Get the resulting connection.
+#if __MonoCS__
+                                var tupleResult = innerConnectionTask.GetAwaiter().GetResult();
+                                HttpConnection result = tupleResult.Item1;
+                                HttpResponseMessage response = tupleResult.Item2;
+#else
                                 (HttpConnection result, HttpResponseMessage response) = innerConnectionTask.GetAwaiter().GetResult();
+#endif
 
                                 if (response != null)
                                 {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.Unix.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.Unix.cs
@@ -71,6 +71,7 @@ namespace System.Net.Http.Functional.Tests
 
         [Fact]
         [PlatformSpecific(~TestPlatforms.OSX)] // Not implemented
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono)]
         public void HttpClientUsesSslCertEnvironmentVariables()
         {
             // We set SSL_CERT_DIR and SSL_CERT_FILE to empty locations.

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -256,6 +256,13 @@ namespace System.Net.Http.Functional.Tests
         {
             if (!BackendSupportsSslConfiguration)
                 return;
+            if (allowedProtocol == SslProtocols.Ssl2 || allowedProtocol == SslProtocols.Ssl3)
+            {
+                // Mono does not allow Ssl2 or Ssl3; an attempt to set it via `SslOptions` will be
+                // silently ignored and the default of Tls 1.0 min / Tls 1.2 max will be used.
+                if (!PlatformDetection.IsSsl2AndSsl3Supported)
+                    return;
+            }
             using (HttpClientHandler handler = CreateHttpClientHandler())
             using (var client = new HttpClient(handler))
             {

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -611,6 +611,7 @@ namespace System.Net.Http.Functional.Tests
         }
     }
 
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Mono)]
     public sealed class SocketsHttpHandler_ConnectionUpgrade_Test : HttpClientTestBase
     {
         protected override bool UseSocketsHttpHandler => true;
@@ -1401,6 +1402,7 @@ namespace System.Net.Http.Functional.Tests
         }
     }
 
+    [SkipOnTargetFramework(TargetFrameworkMonikers.Mono)]
     public sealed class SocketsHttpHandler_ExternalConfiguration_Test : HttpClientTestBase
     {
         private const string EnvironmentVariableSettingName = "DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER";

--- a/src/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
@@ -114,6 +114,7 @@ namespace System.Net.Http.Tests
         [InlineData("HTTP://ABC.COM/", "abc.com", "80", null, null)]
         [InlineData("http://10.30.62.64:7890/", "10.30.62.64", "7890", null, null)]
         [InlineData("http://1.2.3.4:8888/foo", "1.2.3.4", "8888", null, null)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono)]
         public void HttpProxy_Uri_Parsing(string _input, string _host, string _port, string _user , string _password)
         {
             RemoteInvoke((input, host, port, user, password) =>


### PR DESCRIPTION
This PR brings a few Mono-specific changes that are required to adopt the HttpClient from CoreFX.

- MCS compilation in `HttpConnectionPool`.
- BTLS does not support certificate revocation checks.
- AppleTls does not support the `X509Chain`.
- We do not allow `Ssl2` and `Ssl3`.

TODO:

- [ ] `SocketsHttpHandler_ConnectionUpgrade_Test`
- [ ] `SocketsHttpHandler_ExternalConfiguration_Test`
- [ ] `HttpEnvironmentProxyTest /HttpProxy_Uri_Parsing`
