### PR TITLE
Make Brotli more mono frienly

### DIFF
--- a/src/Native/AnyOS/brotli/common/constants.h
+++ b/src/Native/AnyOS/brotli/common/constants.h
@@ -54,4 +54,8 @@
 #define BROTLI_WINDOW_GAP 16
 #define BROTLI_MAX_BACKWARD_LIMIT(W) (((size_t)1 << (W)) - BROTLI_WINDOW_GAP)
 
+#ifndef DLLEXPORT
+#define DLLEXPORT __attribute__ ((__visibility__ ("default")))
+#endif
+
 #endif  /* BROTLI_COMMON_CONSTANTS_H_ */

--- a/src/Native/AnyOS/brotli/dec/decode.c
+++ b/src/Native/AnyOS/brotli/dec/decode.c
@@ -68,7 +68,7 @@ BROTLI_BOOL BrotliDecoderSetParameter(
   }
 }
 
-BrotliDecoderState* BrotliDecoderCreateInstance(
+DLLEXPORT BrotliDecoderState* BrotliDecoderCreateInstance(
     brotli_alloc_func alloc_func, brotli_free_func free_func, void* opaque) {
   BrotliDecoderState* state = 0;
   if (!alloc_func && !free_func) {
@@ -86,7 +86,7 @@ BrotliDecoderState* BrotliDecoderCreateInstance(
 }
 
 /* Deinitializes and frees BrotliDecoderState instance. */
-void BrotliDecoderDestroyInstance(BrotliDecoderState* state) {
+DLLEXPORT void BrotliDecoderDestroyInstance(BrotliDecoderState* state) {
   if (!state) {
     return;
   } else {
@@ -1874,7 +1874,7 @@ static BROTLI_NOINLINE BrotliDecoderErrorCode SafeProcessCommands(
   return ProcessCommandsInternal(1, s);
 }
 
-BrotliDecoderResult BrotliDecoderDecompress(
+DLLEXPORT BrotliDecoderResult BrotliDecoderDecompress(
     size_t encoded_size, const uint8_t* encoded_buffer, size_t* decoded_size,
     uint8_t* decoded_buffer) {
   BrotliDecoderState s;
@@ -1907,7 +1907,7 @@ BrotliDecoderResult BrotliDecoderDecompress(
     * when result is "success" decoder MUST return all unused data back to input
       buffer; this is possible because the invariant is hold on enter
 */
-BrotliDecoderResult BrotliDecoderDecompressStream(
+DLLEXPORT BrotliDecoderResult BrotliDecoderDecompressStream(
     BrotliDecoderState* s, size_t* available_in, const uint8_t** next_in,
     size_t* available_out, uint8_t** next_out, size_t* total_out) {
   BrotliDecoderErrorCode result = BROTLI_DECODER_SUCCESS;
@@ -2351,7 +2351,7 @@ BROTLI_BOOL BrotliDecoderIsUsed(const BrotliDecoderState* s) {
       BrotliGetAvailableBits(&s->br) != 0);
 }
 
-BROTLI_BOOL BrotliDecoderIsFinished(const BrotliDecoderState* s) {
+DLLEXPORT BROTLI_BOOL BrotliDecoderIsFinished(const BrotliDecoderState* s) {
   return TO_BROTLI_BOOL(s->state == BROTLI_STATE_DONE) &&
       !BrotliDecoderHasMoreOutput(s);
 }

--- a/src/Native/AnyOS/brotli/enc/encode.c
+++ b/src/Native/AnyOS/brotli/enc/encode.c
@@ -130,7 +130,7 @@ static size_t RemainingInputBlockSize(BrotliEncoderState* s) {
   return block_size - (size_t)delta;
 }
 
-BROTLI_BOOL BrotliEncoderSetParameter(
+DLLEXPORT BROTLI_BOOL BrotliEncoderSetParameter(
     BrotliEncoderState* state, BrotliEncoderParameter p, uint32_t value) {
   /* Changing parameters on the fly is not implemented yet. */
   if (state->is_initialized_) return BROTLI_FALSE;
@@ -718,7 +718,7 @@ static void BrotliEncoderInitState(BrotliEncoderState* s) {
   memcpy(s->saved_dist_cache_, s->dist_cache_, sizeof(s->saved_dist_cache_));
 }
 
-BrotliEncoderState* BrotliEncoderCreateInstance(brotli_alloc_func alloc_func,
+DLLEXPORT BrotliEncoderState* BrotliEncoderCreateInstance(brotli_alloc_func alloc_func,
                                                 brotli_free_func free_func,
                                                 void* opaque) {
   BrotliEncoderState* state = 0;
@@ -753,7 +753,7 @@ static void BrotliEncoderCleanupState(BrotliEncoderState* s) {
 }
 
 /* Deinitializes and frees BrotliEncoderState instance. */
-void BrotliEncoderDestroyInstance(BrotliEncoderState* state) {
+DLLEXPORT void BrotliEncoderDestroyInstance(BrotliEncoderState* state) {
   if (!state) {
     return;
   } else {
@@ -1335,7 +1335,7 @@ static size_t MakeUncompressedStream(
   return result;
 }
 
-BROTLI_BOOL BrotliEncoderCompress(
+DLLEXPORT BROTLI_BOOL BrotliEncoderCompress(
     int quality, int lgwin, BrotliEncoderMode mode, size_t input_size,
     const uint8_t* input_buffer, size_t* encoded_size,
     uint8_t* encoded_buffer) {
@@ -1655,7 +1655,7 @@ static void UpdateSizeHint(BrotliEncoderState* s, size_t available_in) {
   }
 }
 
-BROTLI_BOOL BrotliEncoderCompressStream(
+DLLEXPORT BROTLI_BOOL BrotliEncoderCompressStream(
     BrotliEncoderState* s, BrotliEncoderOperation op, size_t* available_in,
     const uint8_t** next_in, size_t* available_out,uint8_t** next_out,
     size_t* total_out) {
@@ -1732,7 +1732,7 @@ BROTLI_BOOL BrotliEncoderIsFinished(BrotliEncoderState* s) {
       !BrotliEncoderHasMoreOutput(s));
 }
 
-BROTLI_BOOL BrotliEncoderHasMoreOutput(BrotliEncoderState* s) {
+DLLEXPORT BROTLI_BOOL BrotliEncoderHasMoreOutput(BrotliEncoderState* s) {
   return TO_BROTLI_BOOL(s->available_out_ != 0);
 }
 

--- a/src/System.IO.Compression.Brotli/tests/BrotliEncoderTests.cs
+++ b/src/System.IO.Compression.Brotli/tests/BrotliEncoderTests.cs
@@ -67,7 +67,7 @@ namespace System.IO.Compression.Tests
             Assert.False(BrotliDecoder.TryDecompress(source, destination, out int bytesWritten), "TryDecompress completed successfully but should have failed due to too short of a destination array");
             Assert.Equal(0, bytesWritten);
 
-            BrotliDecoder decoder;
+            BrotliDecoder decoder = default;
             var result = decoder.Decompress(source, destination, out int bytesConsumed, out bytesWritten);
             Assert.Equal(0, bytesWritten);
             Assert.Equal(0, bytesConsumed);
@@ -89,7 +89,7 @@ namespace System.IO.Compression.Tests
             Assert.False(BrotliDecoder.TryDecompress(source, destination, out int bytesWritten), "TryDecompress completed successfully but should have failed due to too short of a source array");
             Assert.Equal(0, bytesWritten);
 
-            BrotliDecoder decoder;
+            BrotliDecoder decoder = default;
             var result = decoder.Decompress(source, destination, out int bytesConsumed, out bytesWritten);
             Assert.Equal(0, bytesWritten);
             Assert.Equal(0, bytesConsumed);
@@ -112,7 +112,7 @@ namespace System.IO.Compression.Tests
             Assert.False(BrotliEncoder.TryCompress(source, destination, out int bytesWritten), "TryCompress completed successfully but should have failed due to too short of a destination array");
             Assert.Equal(0, bytesWritten);
 
-            BrotliEncoder encoder;
+            BrotliEncoder encoder = default;
             var result = encoder.Compress(source, destination, out int bytesConsumed, out bytesWritten, false);
             Assert.Equal(0, bytesWritten);
             Assert.Equal(0, bytesConsumed);
@@ -140,7 +140,7 @@ namespace System.IO.Compression.Tests
             // The only byte written should be the Brotli end of stream byte which varies based on the window/quality
             Assert.Equal(1, bytesWritten);
 
-            BrotliEncoder encoder;
+            BrotliEncoder encoder = default;
             var result = encoder.Compress(source, destination, out int bytesConsumed, out bytesWritten, false);
             Assert.Equal(0, bytesWritten);
             Assert.Equal(0, bytesConsumed);
@@ -160,8 +160,8 @@ namespace System.IO.Compression.Tests
         {
             int chunkSize = 100;
             int totalSize = 20000;
-            BrotliEncoder encoder;
-            BrotliDecoder decoder;
+            BrotliEncoder encoder = default;
+            BrotliDecoder decoder = default;
             for (int i = 0; i < totalSize; i += chunkSize)
             {
                 byte[] uncompressed = new byte[chunkSize];
@@ -329,7 +329,7 @@ namespace System.IO.Compression.Tests
 
         public static void Compress_WithState(ReadOnlySpan<byte> input, Span<byte> output)
         {
-            BrotliEncoder encoder;
+            BrotliEncoder encoder = default;
             while (!input.IsEmpty && !output.IsEmpty)
             {
                 encoder.Compress(input, output, out int bytesConsumed, out int written, isFinalBlock: false);
@@ -341,7 +341,7 @@ namespace System.IO.Compression.Tests
 
         public static void Decompress_WithState(ReadOnlySpan<byte> input, Span<byte> output)
         {
-            BrotliDecoder decoder;
+            BrotliDecoder decoder = default;
             while (!input.IsEmpty && !output.IsEmpty)
             {
                 decoder.Decompress(input, output, out int bytesConsumed, out int written);


### PR DESCRIPTION
some tests use that bug and don't initialize structures (because of reference assemblies where those structs are empty) and it doesn't compile under mono.

Added DLLEXPORT. I added that macro to `constant.h` instead of just referencing `#include pal_compiler` in case if we decide to move to a separate file.

Needed for https://github.com/mono/mono/pull/12189