### PR TITLE
Fix build issue with FileSystemWatcher on Windows

### DIFF
--- a/src/Common/src/Interop/Windows/kernel32/Interop.ReadDirectoryChangesW.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.ReadDirectoryChangesW.cs
@@ -15,7 +15,7 @@ internal partial class Interop
         internal static extern unsafe bool ReadDirectoryChangesW(
             SafeFileHandle hDirectory, 
             byte[] lpBuffer, 
-            int nBufferLength, 
+            uint nBufferLength, 
             [MarshalAs(UnmanagedType.Bool)] bool bWatchSubtree, 
             int dwNotifyFilter, 
             out int lpBytesReturned,


### PR DESCRIPTION
This fixes a build issue `D:\j\workspace\x\external\corefx\src\System.IO.FileSystem.Watcher\src\System\IO\FileSystemWatcher.Win32.cs(158,21): error CS1503: Argument 3: cannot convert from 'uint' to 'int'`. 

It's due to https://github.com/mono/corefx/pull/225/files#diff-a1c7bb639ce6ccca85ec565c2b27664aR51.

Relates to https://github.com/mono/mono/pull/12197