### PR TITLE
Avoid a crash in FileSystemWatcher when UnscheduleFromRunLoop is called from the finalizer on shutdown

### DIFF
--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
@@ -257,6 +257,9 @@ namespace System.IO
                     {
                         lock (s_lockObject)
                         {
+#if MONO
+                            s_watcherRunLoop = IntPtr.Zero;
+#endif                                                        
                             Interop.CoreFoundation.CFRelease(runLoop);
                         }
                     }


### PR DESCRIPTION
@lambdageek  helped to investigate an issue:  https://github.com/mono/mono/pull/12197#issuecomment-450197600

It looks like CoreCLR doesn't run finalizers on shutdown so it's probably some codepath that doesn't get tested (but initially it was presented in upstream PR https://github.com/dotnet/corefx/pull/33865#discussion_r242200515)

Stacktrace:
```
CSC     [net_4_x-macos] System.Web.Extensions_standalone_test_net_4_x.dll
MONO_PATH="./../../class/lib/net_4_x-macos:./../../class/lib/net_4_x-macos/tests:.:$MONO_PATH" /Users/builder/jenkins/workspace/test-mono-pull-request-amd64-osx/runtime/mono-wrapper --debug  ../System.Web/Test/tools/standalone-runner.exe System.Web.Extensions_standalone_test_net_4_x.dll
Running tests:
[.Stacktrace:
  at <unknown> <0xffffffff>
  at (wrapper managed-to-native) Interop/RunLoop.CFRunLoopStop (intptr) [0x00013] in <4b0e991e979a40668dec254fe51fee78>:0
  at System.IO.CoreFX.FileSystemWatcher/RunningInstance/StaticWatcherRunLoopManager.UnscheduleFromRunLoop (Microsoft.Win32.SafeHandles.SafeEventStreamHandle) [0x00044] in /Users/builder/jenkins/workspace/test-mono-pull-request-amd64-osx/external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs:226
  at System.IO.CoreFX.FileSystemWatcher/RunningInstance.CancellationCallback () [0x00024] in /Users/builder/jenkins/workspace/test-mono-pull-request-amd64-osx/external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs:279
  at System.IO.CoreFX.FileSystemWatcher/RunningInstance/<>c.<.ctor>b__10_0 (object) [0x00000] in /Users/builder/jenkins/workspace/test-mono-pull-request-amd64-osx/external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs:179
  at System.Threading.CancellationCallbackInfo.ExecutionContextCallback (object) [0x00007] in /Users/builder/jenkins/workspace/test-mono-pull-request-amd64-osx/mcs/class/referencesource/mscorlib/system/threading/CancellationTokenSource.cs:1071
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext,System.Threading.ContextCallback,object,bool) [0x00071] in /Users/builder/jenkins/workspace/test-mono-pull-request-amd64-osx/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:966
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext,System.Threading.ContextCallback,object,bool) [0x00000] in /Users/builder/jenkins/workspace/test-mono-pull-request-amd64-osx/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:908
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext,System.Threading.ContextCallback,object) [0x0002b] in /Users/builder/jenkins/workspace/test-mono-pull-request-amd64-osx/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:897
  at System.Threading.CancellationCallbackInfo.ExecuteCallback () [0x00024] in /Users/builder/jenkins/workspace/test-mono-pull-request-amd64-osx/mcs/class/referencesource/mscorlib/system/threading/CancellationTokenSource.cs:1052
  at System.Threading.CancellationTokenSource.CancellationCallbackCoreWork (System.Threading.CancellationCallbackCoreWorkArguments) [0x00042] in /Users/builder/jenkins/workspace/test-mono-pull-request-amd64-osx/mcs/class/referencesource/mscorlib/system/threading/CancellationTokenSource.cs:902
  at System.Threading.CancellationTokenSource.ExecuteCallbackHandlers (bool) [0x000c0] in /Users/builder/jenkins/workspace/test-mono-pull-request-amd64-osx/mcs/class/referencesource/mscorlib/system/threading/CancellationTokenSource.cs:849
  at System.Threading.CancellationTokenSource.NotifyCancellation (bool) [0x0005f] in /Users/builder/jenkins/workspace/test-mono-pull-request-amd64-osx/mcs/class/referencesource/mscorlib/system/threading/CancellationTokenSource.cs:781
  at System.Threading.CancellationTokenSource.Cancel (bool) [0x00006] in /Users/builder/jenkins/workspace/test-mono-pull-request-amd64-osx/mcs/class/referencesource/mscorlib/system/threading/CancellationTokenSource.cs:397
  at System.Threading.CancellationTokenSource.Cancel () [0x00000] in /Users/builder/jenkins/workspace/test-mono-pull-request-amd64-osx/mcs/class/referencesource/mscorlib/system/threading/CancellationTokenSource.cs:362
  at System.IO.CoreFX.FileSystemWatcher.StopRaisingEvents () [0x00021] in /Users/builder/jenkins/workspace/test-mono-pull-request-amd64-osx/external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs:80
  at System.IO.CoreFX.FileSystemWatcher.FinalizeDispose () [0x00000] in /Users/builder/jenkins/workspace/test-mono-pull-request-amd64-osx/external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs:35
  at System.IO.CoreFX.FileSystemWatcher.Dispose (bool) [0x0002e] in /Users/builder/jenkins/workspace/test-mono-pull-request-amd64-osx/external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs:371
  at System.ComponentModel.Component.Finalize () [0x00000] in /Users/builder/jenkins/workspace/test-mono-pull-request-amd64-osx/mcs/class/referencesource/System/compmod/system/componentmodel/Component.cs:35
  at (wrapper runtime-invoke) object.runtime_invoke_virtual_void__this__ (object,intptr,intptr,intptr) [0x0002b] in <20f945d44df840f69cdb2b0e894f74e9>:0
Cannot transition thread 0x7000002c5000 from STATE_BLOCKING with BEGIN_NO_SAFEPOINTS
make[1]: *** [run-standalone-test] Abort trap: 6
```