### PR TITLE
Support microsecond resolution on access/write times via utimes() sys…

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.UTimes.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.UTimes.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        internal struct TimeValPair
+        {
+            internal long ASec;  // access time (seconds)
+            internal long AUSec; // access time (microseconds)
+            internal long MSec;  // modified time (seconds)
+            internal long MUSec; // modified time (microseconds)
+        }
+
+        /// <summary>
+        /// Sets the last access and last modified time of a file 
+        /// </summary>
+        /// <param name="path">The path to the item to get time values for</param>
+        /// <param name="time">The output time values of the item</param>
+        /// <returns>
+        /// Returns 0 on success; otherwise, returns -1 
+        /// </returns>
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_UTimes", SetLastError = true)]
+        internal static extern int UTimes(string path, ref TimeValPair times);
+    }
+}

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -1314,22 +1314,21 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destinationFd)
     while ((ret = fstat_(inFd, &sourceStat)) < 0 && errno == EINTR);
     if (ret == 0)
     {
-#if HAVE_FUTIMES
-        struct timeval origTimes[2];
-        origTimes[0].tv_sec = sourceStat.st_atime;
-        origTimes[0].tv_usec = ST_ATIME_NSEC(&sourceStat) / 1000;
-        origTimes[1].tv_sec = sourceStat.st_mtime;
-        origTimes[1].tv_usec = ST_MTIME_NSEC(&sourceStat) / 1000;
-        while ((ret = futimes(outFd, origTimes)) < 0 && errno == EINTR);
-#elif HAVE_FUTIMENS
-        // futimes is not a POSIX function, and not available on Android,
-        // but futimens is
+#if HAVE_FUTIMENS
+        // futimens is prefered because it has a higher resolution.
         struct timespec origTimes[2];
         origTimes[0].tv_sec = (time_t)sourceStat.st_atime;
         origTimes[0].tv_nsec = ST_ATIME_NSEC(&sourceStat);
         origTimes[1].tv_sec = (time_t)sourceStat.st_mtime;
         origTimes[1].tv_nsec = ST_MTIME_NSEC(&sourceStat);
         while ((ret = futimens(outFd, origTimes)) < 0 && errno == EINTR);
+#elif HAVE_FUTIMES
+        struct timeval origTimes[2];
+        origTimes[0].tv_sec = sourceStat.st_atime;
+        origTimes[0].tv_usec = ST_ATIME_NSEC(&sourceStat) / 1000;
+        origTimes[1].tv_sec = sourceStat.st_mtime;
+        origTimes[1].tv_usec = ST_MTIME_NSEC(&sourceStat) / 1000;
+        while ((ret = futimes(outFd, origTimes)) < 0 && errno == EINTR);
 #endif
     }
     if (ret != 0)

--- a/src/Native/Unix/System.Native/pal_time.c
+++ b/src/Native/Unix/System.Native/pal_time.c
@@ -26,6 +26,14 @@ static void ConvertUTimBuf(const UTimBuf* pal, struct utimbuf* native)
     native->modtime = (time_t)(pal->ModTime);
 }
 
+static void ConvertTimeValPair(const TimeValPair* pal, struct timeval native[2])
+{
+    native[0].tv_sec = (long)(pal->AcTimeSec);
+    native[0].tv_usec = (long)(pal->AcTimeUSec);
+    native[1].tv_sec = (long)(pal->ModTimeSec);
+    native[1].tv_usec = (long)(pal->ModTimeUSec);
+}
+
 int32_t SystemNative_UTime(const char* path, UTimBuf* times)
 {
     assert(times != NULL);
@@ -37,6 +45,19 @@ int32_t SystemNative_UTime(const char* path, UTimBuf* times)
     while (CheckInterrupted(result = utime(path, &temp)));
     return result;
 }
+
+int32_t SystemNative_UTimes(const char* path, TimeValPair* times)
+{
+    assert(times != NULL);
+
+    struct timeval temp [2];
+    ConvertTimeValPair(times, temp);
+
+    int32_t result;
+    while (CheckInterrupted(result = utimes(path, temp)));
+    return result;
+}
+
 
 int32_t SystemNative_GetTimestampResolution(uint64_t* resolution)
 {

--- a/src/Native/Unix/System.Native/pal_time.h
+++ b/src/Native/Unix/System.Native/pal_time.h
@@ -16,12 +16,27 @@ typedef struct UTimBuf
     int64_t ModTime;
 } UTimBuf;
 
+typedef struct TimeValPair
+{
+    int64_t AcTimeSec;
+    int64_t AcTimeUSec;
+    int64_t ModTimeSec;
+    int64_t ModTimeUSec;
+} TimeValPair;
+
 /**
  * Sets the last access and last modified time of a file
  *
  * Returns 0 on success; otherwise, returns -1 and errno is set.
  */
 DLLEXPORT int32_t SystemNative_UTime(const char* path, UTimBuf* time);
+
+/**
+ * Sets the last access and last modified time of a file (with microsecond granularity)
+ *
+ * Returns 0 on success; otherwise, returns -1 and errno is set.
+ */
+DLLEXPORT int32_t SystemNative_UTimes(const char* path, TimeValPair* times);
 
 /**
  * Gets the resolution of the timestamp, in counts per second.

--- a/src/System.IO.FileSystem/tests/File/ReadWriteAllBytesAsync.cs
+++ b/src/System.IO.FileSystem/tests/File/ReadWriteAllBytesAsync.cs
@@ -22,6 +22,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "CoreFX FileStream not yet imported")]
         public async Task InvalidParametersAsync()
         {
             string path = GetTestFilePath();

--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -18,6 +18,48 @@ namespace System.IO.Tests
             return new FileInfo(path);
         }
 
+        private static bool HasNonZeroNanoseconds(DateTime dt) => dt.Ticks % 10 != 0;
+        
+        public FileInfo GetNonZeroMilliseconds()
+        {
+            FileInfo fileinfo = new FileInfo(GetTestFilePath());
+            for (int i = 0; i < 5; i++)
+            {
+                fileinfo.Create().Dispose();
+                if (fileinfo.LastWriteTime.Millisecond != 0)
+                    break;
+
+                // This case should only happen 1/1000 times, unless the OS/Filesystem does
+                // not support millisecond granularity.
+
+                // If it's 1/1000, or low granularity, this may help:
+                Thread.Sleep(1234);
+            }
+
+            Assert.NotEqual(0, fileinfo.LastWriteTime.Millisecond);
+            return fileinfo;
+        }
+
+        public FileInfo GetNonZeroNanoseconds()
+        {
+            FileInfo fileinfo = new FileInfo(GetTestFilePath());
+            for (int i = 0; i < 5; i++)
+            {
+                fileinfo.Create().Dispose();
+                if (HasNonZeroNanoseconds(fileinfo.LastWriteTime))
+                    break;
+
+                // This case should only happen 1/10 times, unless the OS/Filesystem does
+                // not support nanosecond granularity.
+
+                // If it's 1/10, or low granularity, this may help:
+                Thread.Sleep(123);
+            }
+            
+            Assert.True(HasNonZeroNanoseconds(fileinfo.LastWriteTime), "Tests failed to create a file with non-zero nanoseconds.");
+            return fileinfo;
+        }
+
         public override FileInfo GetMissingItem() => new FileInfo(GetTestFilePath());
 
         public override string GetItemPath(FileInfo item) => item.FullName;
@@ -70,25 +112,64 @@ namespace System.IO.Tests
         [ConditionalFact(nameof(isNotHFS))]
         public void CopyToMillisecondPresent()
         {
-            FileInfo input = new FileInfo(GetTestFilePath());
-            for (int i = 0; i < 5; i++)
-            {
-                input.Create().Dispose();
-                if (input.LastWriteTime.Millisecond != 0)
-                    break;
-
-                // This case should only happen 1/1000 times, unless the OS/Filesystem does
-                // not support millisecond granularity.
-
-                // If it's 1/1000, or low granularity, this may help:
-                Thread.Sleep(1234);
-            }
-
+            FileInfo input = GetNonZeroMilliseconds();
             FileInfo output = new FileInfo(Path.Combine(GetTestFilePath(), input.Name));
+
             Assert.Equal(0, output.LastWriteTime.Millisecond);
             output.Directory.Create();
             output = input.CopyTo(output.FullName, true);
-            Assert.NotEqual(0, input.LastWriteTime.Millisecond);
+
+            Assert.Equal(input.LastWriteTime.Millisecond, output.LastWriteTime.Millisecond);
+            Assert.NotEqual(0, output.LastWriteTime.Millisecond);
+        }
+
+        [ConditionalFact(nameof(isNotHFS))]
+        public void CopyToNanosecondsPresent()
+        {
+            FileInfo input = GetNonZeroNanoseconds();
+            FileInfo output = new FileInfo(Path.Combine(GetTestFilePath(), input.Name));
+
+            output.Directory.Create();
+            output = input.CopyTo(output.FullName, true);
+
+            Assert.Equal(input.LastWriteTime.Ticks, output.LastWriteTime.Ticks);
+            Assert.True(HasNonZeroNanoseconds(output.LastWriteTime));
+        }
+
+        [ConditionalFact(nameof(isHFS))]
+        public void CopyToNanosecondsPresent_HFS()
+        {
+            FileInfo input = new FileInfo(GetTestFilePath());
+            input.Create().Dispose();
+            FileInfo output = new FileInfo(Path.Combine(GetTestFilePath(), input.Name));
+
+            output.Directory.Create();
+            output = input.CopyTo(output.FullName, true);
+
+            Assert.Equal(input.LastWriteTime.Ticks, output.LastWriteTime.Ticks);
+            Assert.False(HasNonZeroNanoseconds(output.LastWriteTime));
+        }
+
+        [ConditionalFact(nameof(isHFS))]
+        public void MoveToMillisecondPresent_HFS()
+        {
+            FileInfo input = new FileInfo(GetTestFilePath());
+            input.Create().Dispose();
+
+            string dest = Path.Combine(input.DirectoryName, GetTestFileName());
+            input.MoveTo(dest);
+            FileInfo output = new FileInfo(dest);
+            Assert.Equal(0, output.LastWriteTime.Millisecond);
+        }
+
+        [ConditionalFact(nameof(isNotHFS))]
+        public void MoveToMillisecondPresent()
+        {
+            FileInfo input = GetNonZeroMilliseconds();
+            string dest = Path.Combine(input.DirectoryName, GetTestFileName());
+
+            input.MoveTo(dest);
+            FileInfo output = new FileInfo(dest);
             Assert.NotEqual(0, output.LastWriteTime.Millisecond);
         }
 
@@ -100,59 +181,8 @@ namespace System.IO.Tests
             FileInfo output = new FileInfo(Path.Combine(GetTestFilePath(), input.Name));
             output.Directory.Create();
             output = input.CopyTo(output.FullName, true);
-            Assert.Equal(0, input.LastWriteTime.Millisecond);
+            Assert.Equal(input.LastWriteTime.Millisecond, output.LastWriteTime.Millisecond);
             Assert.Equal(0, output.LastWriteTime.Millisecond);
-        }
-
-        [Fact]
-        public void CopyToMillisecondPresent()
-        {
-            FileInfo input = new FileInfo(Path.Combine(TestDirectory, GetTestFileName()));
-            input.Create().Dispose();
-
-            string driveFormat = new DriveInfo(input.DirectoryName).DriveFormat;
-            if (!driveFormat.Equals(HFS, StringComparison.InvariantCultureIgnoreCase))
-            {
-                for (int i = 0; i < 5; i++)
-                {
-                    if (input.LastWriteTime.Millisecond != 0)
-                        break;
-
-                    // This case should only happen 1/1000 times, unless the OS/Filesystem does
-                    // not support millisecond granularity.
-
-                    // If it's 1/1000, or low granularity, this may help:
-                    Thread.Sleep(1234);
-                    input = new FileInfo(Path.Combine(TestDirectory, GetTestFileName()));
-                    input.Create().Dispose();
-                }
-
-                FileInfo output = new FileInfo(Path.Combine(TestDirectory, GetTestFileName(), input.Name));
-                Assert.Equal(0, output.LastWriteTime.Millisecond);
-                output.Directory.Create();
-                output = input.CopyTo(output.FullName, true);
-
-                Assert.NotEqual(0, input.LastWriteTime.Millisecond);
-                Assert.NotEqual(0, output.LastWriteTime.Millisecond);
-            }
-        }
-
-        [Fact]
-        [PlatformSpecific(TestPlatforms.OSX)]
-        public void CopyToMillisecondPresent_HFS()
-        {
-            FileInfo input = new FileInfo(Path.Combine(TestDirectory, GetTestFileName()));
-            input.Create().Dispose();
-            FileInfo output = new FileInfo(Path.Combine(TestDirectory, GetTestFileName(), input.Name));
-
-            string driveFormat = new DriveInfo(input.DirectoryName).DriveFormat;
-            if (driveFormat.Equals(HFS, StringComparison.InvariantCultureIgnoreCase))
-            {             
-                output.Directory.Create();
-                output = input.CopyTo(output.FullName, true);
-                Assert.Equal(0, input.LastWriteTime.Millisecond);
-                Assert.Equal(0, output.LastWriteTime.Millisecond);
-            }
         }
 
         [Fact]
@@ -190,8 +220,7 @@ namespace System.IO.Tests
             Assert.InRange(fi.CreationTimeUtc, before, fi.LastWriteTimeUtc);
         }
 
-
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInAppContainer))] // Can't read root in appcontainer
         [PlatformSpecific(TestPlatforms.Windows)]
         public void PageFileHasTimes()
         {


### PR DESCRIPTION
…call

Do not merge yet as a backport of https://github.com/dotnet/corefx/pull/31522 may be used instead