### PR TITLE
"Ice Blue": Add Mono-specific conditionals to SslConnectionInfo.

### DIFF
--- a/src/System.Net.Security/src/System/Net/Security/SslConnectionInfo.OSX.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslConnectionInfo.OSX.cs
@@ -2,11 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if MONO_SECURITY_ALIAS
+extern alias MonoSecurity;
+#endif
+
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Security.Authentication;
 
+#if MONO
+#if MONO_SECURITY_ALIAS
+using MSI = MonoSecurity::Mono.Security.Interface;
+using TlsCipherSuite = MonoSecurity::Mono.Security.Interface.CipherSuiteCode;
+#else
+using MSI = Mono.Security.Interface;
+using TlsCipherSuite = Mono.Security.Interface.CipherSuiteCode;
+#endif
+#else
 using TlsCipherSuite = Interop.AppleCrypto.TlsCipherSuite;
+#endif
 
 namespace System.Net.Security
 {
@@ -22,6 +36,7 @@ namespace System.Net.Security
         // CALG_ECDH_EPHEM
         private const ExchangeAlgorithmType EcDheAlgorithm = (ExchangeAlgorithmType)0xAA06;
 
+#if !MONO
 #if DEBUG
         static SslConnectionInfo()
         {
@@ -57,6 +72,13 @@ namespace System.Net.Security
 
             MapCipherSuite(cipherSuite);
         }
+#else
+        internal SslConnectionInfo(MSI.MonoTlsConnectionInfo monoInfo)
+        {
+            Protocol = (int)monoInfo.ProtocolVersion;
+            MapCipherSuite(monoInfo.CipherSuiteCode);
+        }
+#endif
 
         private void MapCipherSuite(TlsCipherSuite cipherSuite)
         {
@@ -204,10 +226,12 @@ namespace System.Net.Security
                 TlsMapping.Rsa(CipherAlgorithmType.None, HashAlgorithmType.Sha1)
             },
 
+#if !MONO
             {
                 TlsCipherSuite.SSL_RSA_EXPORT_WITH_RC4_40_MD5,
                 TlsMapping.Rsa(CipherAlgorithmType.Rc4, 40, HashAlgorithmType.Md5)
             },
+#endif
 
             {
                 TlsCipherSuite.TLS_RSA_WITH_RC4_128_MD5,
@@ -219,6 +243,7 @@ namespace System.Net.Security
                 TlsMapping.Rsa(CipherAlgorithmType.Rc4, 128, HashAlgorithmType.Sha1)
             },
 
+#if !MONO
             {
                 TlsCipherSuite.SSL_RSA_EXPORT_WITH_RC2_CBC_40_MD5,
                 TlsMapping.Rsa(CipherAlgorithmType.Rc2, 40, HashAlgorithmType.Md5)
@@ -233,12 +258,14 @@ namespace System.Net.Security
                 TlsCipherSuite.SSL_RSA_WITH_DES_CBC_SHA,
                 TlsMapping.Rsa(CipherAlgorithmType.Des, HashAlgorithmType.Sha1)
             },
+#endif
 
             {
                 TlsCipherSuite.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
                 TlsMapping.Rsa(CipherAlgorithmType.TripleDes, HashAlgorithmType.Sha1)
             },
 
+#if !MONO
             {
                 TlsCipherSuite.SSL_DH_DSS_EXPORT_WITH_DES40_CBC_SHA,
                 TlsMapping.DhStatic(CipherAlgorithmType.Des, 40, HashAlgorithmType.Sha1)
@@ -248,12 +275,14 @@ namespace System.Net.Security
                 TlsCipherSuite.SSL_DH_DSS_WITH_DES_CBC_SHA,
                 TlsMapping.DhStatic(CipherAlgorithmType.Des, HashAlgorithmType.Sha1)
             },
+#endif
 
             {
                 TlsCipherSuite.TLS_DH_DSS_WITH_3DES_EDE_CBC_SHA,
                 TlsMapping.DhStatic(CipherAlgorithmType.TripleDes, HashAlgorithmType.Sha1)
             },
 
+#if !MONO
             {
                 TlsCipherSuite.SSL_DH_RSA_EXPORT_WITH_DES40_CBC_SHA,
                 TlsMapping.DhStatic(CipherAlgorithmType.Des, 40, HashAlgorithmType.Sha1)
@@ -263,12 +292,14 @@ namespace System.Net.Security
                 TlsCipherSuite.SSL_DH_RSA_WITH_DES_CBC_SHA,
                 TlsMapping.DhStatic(CipherAlgorithmType.Des, HashAlgorithmType.Sha1)
             },
+#endif
 
             {
                 TlsCipherSuite.TLS_DH_RSA_WITH_3DES_EDE_CBC_SHA,
                 TlsMapping.DhStatic(CipherAlgorithmType.TripleDes, HashAlgorithmType.Sha1)
             },
 
+#if !MONO
             {
                 TlsCipherSuite.SSL_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA,
                 TlsMapping.DhEphem(CipherAlgorithmType.Des, 40, HashAlgorithmType.Sha1)
@@ -278,12 +309,14 @@ namespace System.Net.Security
                 TlsCipherSuite.SSL_DHE_DSS_WITH_DES_CBC_SHA,
                 TlsMapping.DhEphem(CipherAlgorithmType.Des, HashAlgorithmType.Sha1)
             },
+#endif
 
             {
                 TlsCipherSuite.TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA,
                 TlsMapping.DhEphem(CipherAlgorithmType.TripleDes, HashAlgorithmType.Sha1)
             },
 
+#if !MONO
             {
                 TlsCipherSuite.SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA,
                 TlsMapping.DhEphem(CipherAlgorithmType.Des, 40, HashAlgorithmType.Sha1)
@@ -293,22 +326,26 @@ namespace System.Net.Security
                 TlsCipherSuite.SSL_DHE_RSA_WITH_DES_CBC_SHA,
                 TlsMapping.DhEphem(CipherAlgorithmType.Des, HashAlgorithmType.Sha1)
             },
+#endif
 
             {
                 TlsCipherSuite.TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA,
                 TlsMapping.DhEphem(CipherAlgorithmType.TripleDes, HashAlgorithmType.Sha1)
             },
 
+#if !MONO
             {
                 TlsCipherSuite.SSL_DH_anon_EXPORT_WITH_RC4_40_MD5,
                 TlsMapping.DhStatic(CipherAlgorithmType.Rc4, 40, HashAlgorithmType.Md5)
             },
+#endif
 
             {
                 TlsCipherSuite.TLS_DH_anon_WITH_RC4_128_MD5,
                 TlsMapping.DhStatic(CipherAlgorithmType.Rc4, 128, HashAlgorithmType.Md5)
             },
 
+#if !MONO
             {
                 TlsCipherSuite.SSL_DH_anon_EXPORT_WITH_DES40_CBC_SHA,
                 TlsMapping.DhStatic(CipherAlgorithmType.Des, 40, HashAlgorithmType.Sha1)
@@ -318,6 +355,7 @@ namespace System.Net.Security
                 TlsCipherSuite.SSL_DH_anon_WITH_DES_CBC_SHA,
                 TlsMapping.DhStatic(CipherAlgorithmType.Des, HashAlgorithmType.Sha1)
             },
+#endif
 
             {
                 TlsCipherSuite.TLS_DH_anon_WITH_3DES_EDE_CBC_SHA,


### PR DESCRIPTION
Use Mono's `Mono.Security.Interface.CipherSuiteCode` instead of `Interop.AppleCrypto.TlsCipherSuite` and replace the APIs to retrieve it via `SafeSslHandle` and `Interop.AppleCrypto.SslGetProtocolVersion()` `Interop.AppleCrypto.SslGetCipherSuite()` with one using `Mono.Security.Interface.MonoTlsConnectionInfo)`.
    
The mapping table at the end also needs some Mono-specific conditionals because we do not support all those obsolete weak cipher suites (and therefore, our enum doesn't even contain their values).