### PR TITLE
IPAddressParser doesn't accept non-numbers as zoneid

### DIFF
--- a/src/Common/src/System/Net/IPv6AddressHelper.Common.cs
+++ b/src/Common/src/System/Net/IPv6AddressHelper.Common.cs
@@ -143,11 +143,13 @@ namespace System
                                 {
                                     goto case '/';
                                 }
+#if !MONO // zoneId can be a string, see https://github.com/dotnet/corefx/issues/27529
                                 else if (name[i] < '0' || name[i] > '9')
                                 {
                                     // scope ID must only contain digits
                                     return false;
                                 }
+#endif
                             }
                             break;
                         case ']':

--- a/src/System.Net.Primitives/src/System/Net/IPAddressParser.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddressParser.cs
@@ -225,7 +225,11 @@ namespace System.Net
                         if (c < '0' || c > '9')
                         {
                             scope = 0;
+#if MONO // zoneId can be a string, see https://github.com/dotnet/corefx/issues/27529
+                            return true;
+#else
                             return false;
+#endif
                         }
                         result = (result * 10) + (c - '0');
                         if (result > uint.MaxValue)


### PR DESCRIPTION
`IPAddress.Parse("fe80::e8b0:63ff:fee8:6b3b%awdl0")` will crash in .NET Core.
See https://github.com/dotnet/corefx/issues/27529
Will upstream the fix.