### PR TITLE
Use PlatformDetection.IsMono instead of IsSsl2AndSsl3Supported.

### DIFF
--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
@@ -39,7 +39,6 @@ namespace System
         public static bool IsNotWinRTSupported => !IsWinRTSupported;
         public static bool IsNotMacOsHighSierraOrHigher => !IsMacOsHighSierraOrHigher;
 
-        public static bool IsSsl2AndSsl3Supported => false;
         public static bool SupportsX509Chain => true;
         public static bool SupportsCertRevocation => true;
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -260,7 +260,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 // Mono does not allow Ssl2 or Ssl3; an attempt to set it via `SslOptions` will be
                 // silently ignored and the default of Tls 1.0 min / Tls 1.2 max will be used.
-                if (!PlatformDetection.IsSsl2AndSsl3Supported)
+                if (PlatformDetection.IsMono)
                     return;
             }
             using (HttpClientHandler handler = CreateHttpClientHandler())


### PR DESCRIPTION
We already replaced `IsSsl2AndSsl3Supported` with `!IsMono` everywhere else; this was the only place where it was still used.