### PR TITLE
Introducing HttpClient.CreateDefaultHandler().

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
-    public class HttpClient : HttpMessageInvoker
+    public partial class HttpClient : HttpMessageInvoker
     {
         #region Fields
 
@@ -99,8 +99,16 @@ namespace System.Net.Http
 
         #region Constructors
 
+#if !MONO
+        // Allow Mono to provide a custom version in a partial class part.
+        static HttpClient CreateDefaultHandler()
+        {
+            return new HttpClientHandler();
+        }
+#endif
+
         public HttpClient()
-            : this(new HttpClientHandler())
+            : this(CreateDefaultHandler())
         {
         }
 


### PR DESCRIPTION
Add new static `HttpClient.CreateDefaultHandler()` and use it in the default constructor.

Mono will provide a custom version in a parial class part, to allow us to replace the default handler in our mobile profiles.