### PR TITLE
[System.Security.Cryptography] Remove exception filters from SignedCms

### DIFF
--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignedCms.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignedCms.cs
@@ -108,8 +108,13 @@ namespace System.Security.Cryptography.Pkcs
             {
                 return Helpers.EncodeContentInfo(_signedData, Oids.Pkcs7Signed);
             }
-            catch (CryptographicException) when (!Detached)
+            catch (CryptographicException)
             {
+                if (Detached)
+                {
+                    throw;
+                }
+
                 // If we can't write the contents back out then the most likely culprit is an
                 // indefinite length encoding in the content field.  To preserve as much input data
                 // as possible while still maintaining our expectations of sorting any SET OF values,
@@ -233,8 +238,12 @@ namespace System.Security.Cryptography.Pkcs
 
                 return rented.AsSpan(0, bytesWritten).ToArray();
             }
-            catch (Exception) when (contentType != Oids.Pkcs7Data)
+            catch (Exception)
             {
+                if (contentType == Oids.Pkcs7Data)
+                {
+                    throw;
+                }
             }
             finally
             {

--- a/src/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsTests.cs
@@ -980,8 +980,13 @@ namespace System.Security.Cryptography.Pkcs.Tests
                 {
                     signedCms.ComputeSignature(new CmsSigner(cert));
                 }
-                catch (CryptographicException) when (netfxProblem)
+                catch (CryptographicException)
                 {
+                    if (!netfxProblem)
+                    {
+                        throw;
+                    }
+
                     // When no signed or unsigned attributes are present and the signer uses
                     // IssuerAndSerial as the identifier type, NetFx uses an older PKCS7 encoding
                     // of the current CMS one.  The older encoding fails on these inputs because of a


### PR DESCRIPTION
They are not supported by Bitcode/Xamarin.WatchOS.