### PR TITLE
Add conditionals allowing some calenders to be disabled.

### DIFF
--- a/src/Common/src/CoreLib/System/Globalization/DateTimeFormat.cs
+++ b/src/Common/src/CoreLib/System/Globalization/DateTimeFormat.cs
@@ -461,8 +461,8 @@ namespace System
             }
             
             // This is a flag to indicate if we are format the dates using Hebrew calendar.
-            bool isHebrewCalendar = ((CalendarId)cal.ID == CalendarId.HEBREW);
-            bool isJapaneseCalendar = ((CalendarId)cal.ID == CalendarId.JAPAN);
+            bool isHebrewCalendar = !GlobalizationMode.Invariant && ((CalendarId)cal.ID == CalendarId.HEBREW);
+            bool isJapaneseCalendar = !GlobalizationMode.Invariant && ((CalendarId)cal.ID == CalendarId.JAPAN);
             // This is a flag to indicate if we are formating hour/minute/second only.
             bool bTimeOnly = true;
 
@@ -670,7 +670,7 @@ namespace System
                         {
                             FormatDigits(result, year, tokenLen <= 2 ? tokenLen : 2);
                         }
-                        else if ((CalendarId)cal.ID == CalendarId.HEBREW)
+                        else if (isHebrewCalendar)
                         {
                             HebrewFormatDigits(result, year);
                         }

--- a/src/Common/src/CoreLib/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/Common/src/CoreLib/System/Globalization/DateTimeFormatInfo.cs
@@ -301,8 +301,10 @@ namespace System.Globalization
         // Invariant DateTimeFormatInfo doesn't have user-overriden values
         // Default calendar is gregorian
         public DateTimeFormatInfo()
-            : this(CultureInfo.InvariantCulture._cultureData, GregorianCalendar.GetDefaultInstance())
         {
+            _cultureData = CultureInfo.InvariantCulture._cultureData;
+            calendar = GregorianCalendar.GetDefaultInstance();
+            InitializeOverridableProperties(_cultureData, calendar.ID);
         }
 
         internal DateTimeFormatInfo(CultureData cultureData, Calendar cal)
@@ -446,6 +448,10 @@ namespace System.Globalization
 
             set
             {
+                if (GlobalizationMode.Invariant)
+                {
+                    throw new PlatformNotSupportedException();
+                }
                 if (IsReadOnly)
                     throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
                 if (value == null)
@@ -1871,7 +1877,7 @@ namespace System.Globalization
         {
             get
             {
-                return (_isReadOnly);
+                return GlobalizationMode.Invariant || (_isReadOnly);
             }
         }
 
@@ -2254,7 +2260,7 @@ namespace System.Globalization
         internal static DateTimeFormatInfo GetJapaneseCalendarDTFI()
         {
             DateTimeFormatInfo temp = s_jajpDTFI;
-            if (temp == null)
+            if (temp == null && !GlobalizationMode.Invariant)
             {
                 temp = new CultureInfo("ja-JP", false).DateTimeFormat;
                 temp.Calendar = JapaneseCalendar.GetDefaultInstance();
@@ -2270,7 +2276,7 @@ namespace System.Globalization
         internal static DateTimeFormatInfo GetTaiwanCalendarDTFI()
         {
             DateTimeFormatInfo temp = s_zhtwDTFI;
-            if (temp == null)
+            if (temp == null && !GlobalizationMode.Invariant)
             {
                 temp = new CultureInfo("zh-TW", false).DateTimeFormat;
                 temp.Calendar = TaiwanCalendar.GetDefaultInstance();
@@ -2294,13 +2300,13 @@ namespace System.Globalization
             {
                 temp = new TokenHashValue[TOKEN_HASH_SIZE];
 
-                bool koreanLanguage = LanguageName.Equals(KoreanLangName);
+                bool koreanLanguage = !GlobalizationMode.Invariant && LanguageName.Equals(KoreanLangName);
 
                 string sep = this.TimeSeparator.Trim();
                 if (IgnorableComma != sep) InsertHash(temp, IgnorableComma, TokenType.IgnorableSymbol, 0);
                 if (IgnorablePeriod != sep) InsertHash(temp, IgnorablePeriod, TokenType.IgnorableSymbol, 0);
 
-                if (KoreanHourSuff != sep && CJKHourSuff != sep && ChineseHourSuff != sep)
+                if (!GlobalizationMode.Invariant && KoreanHourSuff != sep && CJKHourSuff != sep && ChineseHourSuff != sep)
                 {
                     //
                     // On the Macintosh, the default TimeSeparator is identical to the KoreanHourSuff, CJKHourSuff, or ChineseHourSuff for some cultures like
@@ -2315,46 +2321,48 @@ namespace System.Globalization
                 InsertHash(temp, this.PMDesignator, TokenType.SEP_Pm | TokenType.Pm, 1);
 
                 // TODO: This ignores similar custom cultures
-                if (LanguageName.Equals("sq"))
+                if (!GlobalizationMode.Invariant && LanguageName.Equals("sq"))
                 {
                     // Albanian allows time formats like "12:00.PD"
                     InsertHash(temp, IgnorablePeriod + this.AMDesignator, TokenType.SEP_Am | TokenType.Am, 0);
                     InsertHash(temp, IgnorablePeriod + this.PMDesignator, TokenType.SEP_Pm | TokenType.Pm, 1);
                 }
 
-                // CJK suffix
-                InsertHash(temp, CJKYearSuff, TokenType.SEP_YearSuff, 0);
-                InsertHash(temp, KoreanYearSuff, TokenType.SEP_YearSuff, 0);
-                InsertHash(temp, CJKMonthSuff, TokenType.SEP_MonthSuff, 0);
-                InsertHash(temp, KoreanMonthSuff, TokenType.SEP_MonthSuff, 0);
-                InsertHash(temp, CJKDaySuff, TokenType.SEP_DaySuff, 0);
-                InsertHash(temp, KoreanDaySuff, TokenType.SEP_DaySuff, 0);
-
-                InsertHash(temp, CJKHourSuff, TokenType.SEP_HourSuff, 0);
-                InsertHash(temp, ChineseHourSuff, TokenType.SEP_HourSuff, 0);
-                InsertHash(temp, CJKMinuteSuff, TokenType.SEP_MinuteSuff, 0);
-                InsertHash(temp, CJKSecondSuff, TokenType.SEP_SecondSuff, 0);
-
-
-                if (!AppContextSwitches.EnforceLegacyJapaneseDateParsing && Calendar.ID == (int)CalendarId.JAPAN)
+                if (!GlobalizationMode.Invariant)
                 {
-                    // We need to support parsing the dates has the start of era symbol which means it is year 1 in the era.
-                    // The start of era symbol has to be followed by the year symbol suffix, otherwise it would be invalid date.
-                    InsertHash(temp, JapaneseEraStart, TokenType.YearNumberToken, 1);
-                    InsertHash(temp, "(", TokenType.IgnorableSymbol, 0);
-                    InsertHash(temp, ")", TokenType.IgnorableSymbol, 0);
+                    // CJK suffix
+                    InsertHash(temp, CJKYearSuff, TokenType.SEP_YearSuff, 0);
+                    InsertHash(temp, KoreanYearSuff, TokenType.SEP_YearSuff, 0);
+                    InsertHash(temp, CJKMonthSuff, TokenType.SEP_MonthSuff, 0);
+                    InsertHash(temp, KoreanMonthSuff, TokenType.SEP_MonthSuff, 0);
+                    InsertHash(temp, CJKDaySuff, TokenType.SEP_DaySuff, 0);
+                    InsertHash(temp, KoreanDaySuff, TokenType.SEP_DaySuff, 0);
+
+                    InsertHash(temp, CJKHourSuff, TokenType.SEP_HourSuff, 0);
+                    InsertHash(temp, ChineseHourSuff, TokenType.SEP_HourSuff, 0);
+                    InsertHash(temp, CJKMinuteSuff, TokenType.SEP_MinuteSuff, 0);
+                    InsertHash(temp, CJKSecondSuff, TokenType.SEP_SecondSuff, 0);
+
+                    if (!AppContextSwitches.EnforceLegacyJapaneseDateParsing && Calendar.ID == (int)CalendarId.JAPAN)
+                    {
+                        // We need to support parsing the dates has the start of era symbol which means it is year 1 in the era.
+                        // The start of era symbol has to be followed by the year symbol suffix, otherwise it would be invalid date.
+                        InsertHash(temp, JapaneseEraStart, TokenType.YearNumberToken, 1);
+                        InsertHash(temp, "(", TokenType.IgnorableSymbol, 0);
+                        InsertHash(temp, ")", TokenType.IgnorableSymbol, 0);
+                    }
+
+                    // TODO: This ignores other custom cultures that might want to do something similar
+                    if (koreanLanguage)
+                    {
+                        // Korean suffix
+                        InsertHash(temp, KoreanHourSuff, TokenType.SEP_HourSuff, 0);
+                        InsertHash(temp, KoreanMinuteSuff, TokenType.SEP_MinuteSuff, 0);
+                        InsertHash(temp, KoreanSecondSuff, TokenType.SEP_SecondSuff, 0);
+                    }
                 }
 
-                // TODO: This ignores other custom cultures that might want to do something similar
-                if (koreanLanguage)
-                {
-                    // Korean suffix
-                    InsertHash(temp, KoreanHourSuff, TokenType.SEP_HourSuff, 0);
-                    InsertHash(temp, KoreanMinuteSuff, TokenType.SEP_MinuteSuff, 0);
-                    InsertHash(temp, KoreanSecondSuff, TokenType.SEP_SecondSuff, 0);
-                }
-
-                if (LanguageName.Equals("ky"))
+                if (!GlobalizationMode.Invariant && LanguageName.Equals("ky"))
                 {
                     // For some cultures, the date separator works more like a comma, being allowed before or after any date part
                     InsertHash(temp, dateSeparatorOrTimeZoneOffset, TokenType.IgnorableSymbol, 0);
@@ -2367,9 +2375,13 @@ namespace System.Globalization
                 String[] dateWords = null;
                 DateTimeFormatInfoScanner scanner = null;
 
-                // We need to rescan the date words since we're always synthetic
-                scanner = new DateTimeFormatInfoScanner();
-                dateWords = scanner.GetDateWordsOfDTFI(this);
+                if (!GlobalizationMode.Invariant)
+                {
+                    // We need to rescan the date words since we're always synthetic
+                    scanner = new DateTimeFormatInfoScanner();
+                    dateWords = scanner.GetDateWordsOfDTFI(this);
+                }
+
                 // Ensure the formatflags is initialized.
                 DateTimeFormatFlags flag = FormatFlags;
 
@@ -2379,7 +2391,7 @@ namespace System.Globalization
                 bool useDateSepAsIgnorableSymbol = false;
 
                 String monthPostfix = null;
-                if (dateWords != null)
+                if (!GlobalizationMode.Invariant && dateWords != null)
                 {
                     // There are DateWords.  It could be a real date word (such as "de"), or a monthPostfix.
                     // The monthPostfix starts with '\xfffe' (MonthPostfixChar), followed by the real monthPostfix.
@@ -2470,7 +2482,7 @@ namespace System.Globalization
                 }
 
                 // TODO: This ignores other cultures that might want to do something similar
-                if (LanguageName.Equals(JapaneseLangName))
+                if (!GlobalizationMode.Invariant && LanguageName.Equals(JapaneseLangName))
                 {
                     // Japanese allows day of week forms like: "(Tue)"
                     for (int i = 0; i < 7; i++)
@@ -2493,7 +2505,7 @@ namespace System.Globalization
                     }
                 }
                 // TODO: This prohibits similar custom cultures, but we hard coded the name
-                else if (CultureName.Equals("zh-TW"))
+                else if (!GlobalizationMode.Invariant && CultureName.Equals("zh-TW"))
                 {
                     DateTimeFormatInfo twDtfi = GetTaiwanCalendarDTFI();
                     for (int i = 1; i <= twDtfi.Calendar.Eras.Length; i++)
@@ -2677,7 +2689,7 @@ namespace System.Globalization
             if (isLetter)
             {
                 ch = this.Culture.TextInfo.ToLower(ch);
-                if (IsHebrewChar(ch) && TokenMask == TokenType.RegularTokenMask)
+                if (!GlobalizationMode.Invariant && IsHebrewChar(ch) && TokenMask == TokenType.RegularTokenMask)
                 {
                     bool badFormat;
                     if (TryParseHebrewNumber(ref str, out badFormat, out tokenValue))

--- a/src/Common/src/CoreLib/System/Globalization/DateTimeParse.cs
+++ b/src/Common/src/CoreLib/System/Globalization/DateTimeParse.cs
@@ -15,7 +15,15 @@ namespace System
 
         internal delegate bool MatchNumberDelegate(ref __DTString str, int digitLen, out int result);
 
-        internal static MatchNumberDelegate m_hebrewNumberParser = new MatchNumberDelegate(DateTimeParse.MatchHebrewDigits);
+        internal static MatchNumberDelegate m_hebrewNumberParser;
+
+        static DateTimeParse()
+        {
+            if (!GlobalizationMode.Invariant)
+            {
+                m_hebrewNumberParser = new MatchNumberDelegate(DateTimeParse.MatchHebrewDigits);
+            }
+        }
 
         internal static DateTime ParseExact(ReadOnlySpan<char> s, ReadOnlySpan<char> format, DateTimeFormatInfo dtfi, DateTimeStyles style)
         {
@@ -1051,6 +1059,10 @@ new DS[] { DS.ERROR, DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,  
                     break;
                 case TokenType.JapaneseEraToken:
                     // Special case for Japanese.  We allow Japanese era name to be used even if the calendar is not Japanese Calendar.
+                    if (GlobalizationMode.Invariant)
+                    {
+                        throw new PlatformNotSupportedException();
+                    }
                     result.calendar = JapaneseCalendar.GetDefaultInstance();
                     dtfi = DateTimeFormatInfo.GetJapaneseCalendarDTFI();
                     if (result.era != -1)
@@ -1066,6 +1078,10 @@ new DS[] { DS.ERROR, DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,  
                     }
                     break;
                 case TokenType.TEraToken:
+                    if (GlobalizationMode.Invariant)
+                    {
+                        throw new PlatformNotSupportedException();
+                    }
                     result.calendar = TaiwanCalendar.GetDefaultInstance();
                     dtfi = DateTimeFormatInfo.GetTaiwanCalendarDTFI();
                     if (result.era != -1)
@@ -2292,7 +2308,7 @@ new DS[] { DS.ERROR, DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,  
                         result.SetFailure(ParseFailureKind.FormatBadDateTimeCalendar, nameof(SR.Format_BadDateTimeCalendar));
                         return false;
                     }
-                    if (!GetHebrewDayOfNM(ref result, ref raw, dtfi))
+                    if (!GlobalizationMode.Invariant && !GetHebrewDayOfNM(ref result, ref raw, dtfi))
                     {
                         return false;
                     }
@@ -2634,7 +2650,7 @@ new DS[] { DS.ERROR, DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,  
                     {
                         if ((dtfi.FormatFlags & DateTimeFormatFlags.UseHebrewRule) != 0)
                         {
-                            if (!ProcessHebrewTerminalState(dps, ref str, ref result, ref styles, ref raw, dtfi))
+                            if (!GlobalizationMode.Invariant && !ProcessHebrewTerminalState(dps, ref str, ref result, ref styles, ref raw, dtfi))
                             {
                                 TPTraceExit("0050 (ProcessHebrewTerminalState)", dps);
                                 return false;
@@ -4476,7 +4492,7 @@ new DS[] { DS.ERROR, DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,  
             bool bTimeOnly = false;
             result.calendar = parseInfo.calendar;
 
-            if ((CalendarId)parseInfo.calendar.ID == CalendarId.HEBREW)
+            if (!GlobalizationMode.Invariant && (CalendarId)parseInfo.calendar.ID == CalendarId.HEBREW)
             {
                 parseInfo.parseNumberDelegate = m_hebrewNumberParser;
                 parseInfo.fCustomNumberParser = true;

--- a/src/Common/src/CoreLib/System/Globalization/DateTimeParse.cs
+++ b/src/Common/src/CoreLib/System/Globalization/DateTimeParse.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Text;
 
 namespace System
@@ -16,14 +17,6 @@ namespace System
         internal delegate bool MatchNumberDelegate(ref __DTString str, int digitLen, out int result);
 
         internal static MatchNumberDelegate m_hebrewNumberParser;
-
-        static DateTimeParse()
-        {
-            if (!GlobalizationMode.Invariant)
-            {
-                m_hebrewNumberParser = new MatchNumberDelegate(DateTimeParse.MatchHebrewDigits);
-            }
-        }
 
         internal static DateTime ParseExact(ReadOnlySpan<char> s, ReadOnlySpan<char> format, DateTimeFormatInfo dtfi, DateTimeStyles style)
         {
@@ -4494,6 +4487,7 @@ new DS[] { DS.ERROR, DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,  
 
             if (!GlobalizationMode.Invariant && (CalendarId)parseInfo.calendar.ID == CalendarId.HEBREW)
             {
+                LazyInitializer.EnsureInitialized (ref m_hebrewNumberParser, () => new MatchNumberDelegate(DateTimeParse.MatchHebrewDigits));
                 parseInfo.parseNumberDelegate = m_hebrewNumberParser;
                 parseInfo.fCustomNumberParser = true;
             }

--- a/src/System.Runtime/tests/System/DateTimeOffsetTests.cs
+++ b/src/System.Runtime/tests/System/DateTimeOffsetTests.cs
@@ -1152,7 +1152,10 @@ namespace System.Tests
         [MemberData(nameof(ToString_WithCulture_MatchesExpected_MemberData))]
         public static void ToString_WithCulture_MatchesExpected(DateTimeOffset dateTimeOffset, string format, CultureInfo culture, string expected)
         {
-            Assert.Equal(expected, dateTimeOffset.ToString(format, culture));
+            if (!GlobalizationMode.Invariant)
+            {
+                Assert.Equal(expected, dateTimeOffset.ToString(format, culture));
+            }
         }
     }
 }

--- a/src/System.Runtime/tests/System/DateTimeTests.cs
+++ b/src/System.Runtime/tests/System/DateTimeTests.cs
@@ -989,13 +989,16 @@ namespace System.Tests
             yield return new object[] { "2 2 2Z", CultureInfo.InvariantCulture, TimeZoneInfo.ConvertTimeFromUtc(new DateTime(2002, 2, 2, 0, 0, 0, DateTimeKind.Utc), TimeZoneInfo.Local) };
             yield return new object[] { "#10/10/2095#\0", CultureInfo.InvariantCulture, new DateTime(2095, 10, 10, 0, 0, 0) };
 
-            DateTime today = DateTime.Today;
-            var hebrewCulture = new CultureInfo("he-IL");
-            hebrewCulture.DateTimeFormat.Calendar = new HebrewCalendar();
-            yield return new object[] { today.ToString(hebrewCulture), hebrewCulture, today };
+            if (!GlobalizationMode.Invariant)
+            {
+                DateTime today = DateTime.Today;
+                var hebrewCulture = new CultureInfo("he-IL");
+                hebrewCulture.DateTimeFormat.Calendar = new HebrewCalendar();
+                yield return new object[] { today.ToString(hebrewCulture), hebrewCulture, today };
 
-            var mongolianCulture = new CultureInfo("mn-MN");
-            yield return new object[] { today.ToString(mongolianCulture), mongolianCulture, today };
+                var mongolianCulture = new CultureInfo("mn-MN");
+                yield return new object[] { today.ToString(mongolianCulture), mongolianCulture, today };
+            }
         }
 
         [Theory]
@@ -1099,6 +1102,11 @@ namespace System.Tests
             yield return new object[] { "1234-05-06T07:00:00Z", "yyyy-MM-dd'T'HH:mm:ssFFF'Z'\'  \'", CultureInfo.InvariantCulture, DateTimeStyles.AllowTrailingWhite, new DateTime(1234, 5, 6, 7, 0, 0, 0) };
             yield return new object[] { "1234-05-06T07:00:00Z", "yyyy-MM-dd'T'HH:mm:ssFFFZ\" \"", CultureInfo.InvariantCulture, DateTimeStyles.AllowTrailingWhite, TimeZoneInfo.ConvertTimeFromUtc(new DateTime(1234, 5, 6, 7, 0, 0, DateTimeKind.Utc), TimeZoneInfo.Local) };
             yield return new object[] { "1234-05-06T07:00:00GMT", "yyyy-MM-dd'T'HH:mm:ssFFFZ\"  \"", CultureInfo.InvariantCulture, DateTimeStyles.AllowTrailingWhite, TimeZoneInfo.ConvertTimeFromUtc(new DateTime(1234, 5, 6, 7, 0, 0, DateTimeKind.Utc), TimeZoneInfo.Local) };
+
+            if (GlobalizationMode.Invariant)
+            {
+                yield break;
+            }
 
 
             var hebrewCulture = new CultureInfo("he-IL");

--- a/src/System.Runtime/tests/System/TimeSpanTests.cs
+++ b/src/System.Runtime/tests/System/TimeSpanTests.cs
@@ -574,9 +574,12 @@ namespace System.Tests
             yield return new object[] { "23:00:00", null, new TimeSpan(23, 0, 0) };
             yield return new object[] { "24:00:00", null, new TimeSpan(24, 0, 0, 0) };
 
-            // Croatia uses ',' in place of '.'
-            CultureInfo croatianCulture = new CultureInfo("hr-HR");
-            yield return new object[] { "6:12:14:45,348", croatianCulture, new TimeSpan(6, 12, 14, 45, 348) };
+            if (!GlobalizationMode.Invariant)
+            {
+                // Croatia uses ',' in place of '.'
+                CultureInfo croatianCulture = new CultureInfo("hr-HR");
+                yield return new object[] { "6:12:14:45,348", croatianCulture, new TimeSpan(6, 12, 14, 45, 348) };
+            }
         }
 
         [Theory]
@@ -621,7 +624,11 @@ namespace System.Tests
             yield return new object[] { "00:00::00", null, typeof(FormatException) }; // duplicated separator
             yield return new object[] { "00:00:00:", null, typeof(FormatException) }; // extra separator at end
             yield return new object[] { "00:00:00:00:00:00:00:00", null, typeof(FormatException) }; // too many components
-            yield return new object[] { "6:12:14:45.3448", new CultureInfo("hr-HR"), typeof(FormatException) }; // culture that uses ',' rather than '.'
+
+            if (!GlobalizationMode.Invariant)
+            {
+                yield return new object[] { "6:12:14:45.3448", new CultureInfo("hr-HR"), typeof(FormatException) }; // culture that uses ',' rather than '.'
+            }
 
             // OverflowExceptions
             yield return new object[] { "1:1:1.99999999", null, typeof(OverflowException) }; // overflowing fraction


### PR DESCRIPTION
Add `GlobalizationMode.Invariant` conditionals to some calendar code.
 
This allows the Japanese, Taiwan and Hebrew calendars to be disabled.