### PR TITLE
Remove Mono-specific `RuntimeFeature` constants.

### DIFF
--- a/src/Common/src/CoreLib/System/Runtime/CompilerServices/RuntimeFeature.cs
+++ b/src/Common/src/CoreLib/System/Runtime/CompilerServices/RuntimeFeature.cs
@@ -40,11 +40,5 @@ namespace System.Runtime.CompilerServices
 
             return false;
         }
-        
-#if MONO
-        // https://github.com/dotnet/coreclr/blob/397aaccb5104844998c3bcf6e9245cc81127e1e2/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.CoreCLR.cs#L9-L10
-        public static bool IsDynamicCodeSupported => true;
-        public static bool IsDynamicCodeCompiled => true;
-#endif
     }
 }


### PR DESCRIPTION
Remove the `#if MONO` conditional part of `RuntimeFeature` (`IsDynamicCodeSupported` and `IsDynamicCodeCompiled`) to put it inside corlib.  This will make it easier to modify these constants on a per-platform level without requiring corefx bumps.