### PR TITLE
Remove Windows-specific p/invokes from tests

### DIFF
--- a/src/Common/tests/System/IO/PathFeatures.cs
+++ b/src/Common/tests/System/IO/PathFeatures.cs
@@ -93,7 +93,11 @@ namespace System.IO
             return s_osEnabled == State.True;
         }
 
+#if MONO && MOBILE
+        private static bool RtlAreLongPathsEnabled() => throw new PlatformNotSupportedException();
+#else
         [DllImport("ntdll", ExactSpelling = true)]
         private static extern bool RtlAreLongPathsEnabled();
+#endif
     }
 }

--- a/src/Common/tests/System/Net/Capability.Sockets.cs
+++ b/src/Common/tests/System/Net/Capability.Sockets.cs
@@ -9,9 +9,13 @@ namespace System.Net.Test.Common
 {
     public static partial class Capability
     {
+#if MONO && MOBILE
+        private static int RtlGetVersion(ref RTL_OSVERSIONINFOW lpVersionInformation) => throw new PlatformNotSupportedException();
+#else
         // TODO: Using RtlGetVersion is temporary until issue #4741 gets resolved.
         [DllImport("ntdll", CharSet = CharSet.Unicode)]
         private static extern int RtlGetVersion(ref RTL_OSVERSIONINFOW lpVersionInformation);
+#endif
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
         private struct RTL_OSVERSIONINFOW

--- a/src/System.IO.FileSystem/tests/PortedCommon/DllImports.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/DllImports.cs
@@ -8,6 +8,15 @@ using System.Text;
 
 internal static class DllImports
 {
+#if MONO && MOBILE
+    internal static int GetLogicalDrives() => throw new PlatformNotSupportedException();
+
+    internal static bool GetDiskFreeSpaceEx(String drive, out long freeBytesForUser, out long totalBytes, out long freeBytes) => throw new PlatformNotSupportedException();
+
+    internal static bool GetVolumeInformation(String drive, [Out]StringBuilder volumeName, int volumeNameBufLen, out int volSerialNumber, out int maxFileNameLen, out int fileSystemFlags, [Out]StringBuilder fileSystemName, int fileSystemNameBufLen) => throw new PlatformNotSupportedException();
+
+    internal static int GetDriveType(string drive) => throw new PlatformNotSupportedException();
+#else
     [DllImport("kernel32.dll", SetLastError = true)]
     internal static extern int GetLogicalDrives();
 
@@ -19,5 +28,6 @@ internal static class DllImports
 
     [DllImport("kernel32.dll", EntryPoint = "GetDriveTypeW", CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
     internal static extern int GetDriveType(string drive);
+#endif
 }
 

--- a/src/System.Runtime.Extensions/tests/System/Environment.ProcessorCount.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.ProcessorCount.cs
@@ -64,8 +64,12 @@ namespace System.Tests
         private static extern long sysconf(int name);
 #endif
 
+#if MONO && MOBILE
+        internal static void GetSystemInfo(ref SYSTEM_INFO lpSystemInfo) => throw new PlatformNotSupportedException();
+#else
         [DllImport("kernel32.dll", SetLastError = true)]
         internal static extern void GetSystemInfo(ref SYSTEM_INFO lpSystemInfo);
+#endif
 
         [StructLayout(LayoutKind.Sequential)]
         internal struct SYSTEM_INFO


### PR DESCRIPTION
They cause issues on iOS where all p/invokes need to be resolved.