### PR TITLE
[2019-02][monodroid] Enable building on win32

### DIFF
--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
@@ -12,7 +12,7 @@ using System.IO.Enumeration;
 using System.Threading;
 using System.Threading.Tasks;
 
-#if MONO && !MOBILE
+#if MONO && (!MOBILE || MOBILE_DESKTOP_HOST)
 
 using System;
 using System.IO;


### PR DESCRIPTION
/cc @alexischr looks like this wasn't merged when https://github.com/mono/mono/pull/14504 was merged.