### PR TITLE
Remove some methods from TaskExtensions

### DIFF
--- a/src/Common/src/CoreLib/System/Threading/Tasks/TaskExtensions.cs
+++ b/src/Common/src/CoreLib/System/Threading/Tasks/TaskExtensions.cs
@@ -48,6 +48,7 @@ namespace System.Threading.Tasks
                 Task.FromCanceled<TResult>(new CancellationToken(true));
         }
 
+#if !MONO // these methods were moved to TaskAsyncEnumerableExtensions
         /// <summary>Configures how awaits on the tasks returned from an async disposable will be performed.</summary>
         /// <param name="source">The source async disposable.</param>
         /// <param name="continueOnCapturedContext">Whether to capture and marshal back to the current context.</param>
@@ -72,5 +73,6 @@ namespace System.Threading.Tasks
         public static ConfiguredCancelableAsyncEnumerable<T> WithCancellation<T>(
             this IAsyncEnumerable<T> source, CancellationToken cancellationToken) =>
             new ConfiguredCancelableAsyncEnumerable<T>(source, continueOnCapturedContext: true, cancellationToken);
+#endif
     }
 }

--- a/src/System.Threading.Tasks/tests/System.Runtime.CompilerServices/ConfiguredCancelableAsyncEnumerableTests.netcoreapp.cs
+++ b/src/System.Threading.Tasks/tests/System.Runtime.CompilerServices/ConfiguredCancelableAsyncEnumerableTests.netcoreapp.cs
@@ -35,7 +35,7 @@ namespace System.Runtime.CompilerServices.Tests
         [Fact]
         public void Default_WithCancellation_ConfigureAwait_NoThrow()
         {
-            ConfiguredCancelableAsyncEnumerable<int> e = TaskExtensions.WithCancellation((IAsyncEnumerable<int>)null, default);
+            ConfiguredCancelableAsyncEnumerable<int> e = ((IAsyncEnumerable<int>)null).WithCancellation(default);
             e = e.ConfigureAwait(false);
             e = e.WithCancellation(default);
             Assert.Throws<NullReferenceException>(() => e.GetAsyncEnumerator());
@@ -44,7 +44,7 @@ namespace System.Runtime.CompilerServices.Tests
         [Fact]
         public void Default_ConfigureAwait_WithCancellation_NoThrow()
         {
-            ConfiguredCancelableAsyncEnumerable<int> e = TaskExtensions.ConfigureAwait((IAsyncEnumerable<int>)null, false);
+            ConfiguredCancelableAsyncEnumerable<int> e = ((IAsyncEnumerable<int>)null).ConfigureAwait(false);
             e = e.WithCancellation(default);
             e = e.ConfigureAwait(false);
             Assert.Throws<NullReferenceException>(() => e.GetAsyncEnumerator());


### PR DESCRIPTION
Those were moved to TaskAsyncEnumerableExtensions in the upstream (our fork doesn't have it)
And copy-paste `ConfiguredCancelableAsyncEnumerableTests.netcoreapp.cs ` tests from the upstream