### PR TITLE
Synchronize NS21 changes with upstream

### DIFF
--- a/src/Common/src/CoreLib/System/Collections/ObjectModel/Collection.cs
+++ b/src/Common/src/CoreLib/System/Collections/ObjectModel/Collection.cs
@@ -71,8 +71,6 @@ namespace System.Collections.ObjectModel
             InsertItem(index, item);
         }
 
-        public void AddRange(IEnumerable<T> collection) => InsertItemsRange(items.Count, collection);
-
         public void Clear()
         {
             if (items.IsReadOnly)
@@ -118,26 +116,6 @@ namespace System.Collections.ObjectModel
             InsertItem(index, item);
         }
 
-        public void InsertRange(int index, IEnumerable<T> collection)
-        {
-            if (items.IsReadOnly)
-            {
-                ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_ReadOnlyCollection);
-            }
-
-            if (collection == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.collection);
-            }
-
-            if ((uint)index > (uint)items.Count)
-            {
-                ThrowHelper.ThrowArgumentOutOfRange_IndexException();
-            }
-
-            InsertItemsRange(index, collection);
-        }
-
         public bool Remove(T item)
         {
             if (items.IsReadOnly)
@@ -149,61 +127,6 @@ namespace System.Collections.ObjectModel
             if (index < 0) return false;
             RemoveItem(index);
             return true;
-        }
-
-        public void RemoveRange(int index, int count)
-        {
-            if (items.IsReadOnly)
-            {
-                ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_ReadOnlyCollection);
-            }
-
-            if ((uint)index > (uint)items.Count)
-            {
-                ThrowHelper.ThrowArgumentOutOfRange_IndexException();
-            }
-
-            if (count < 0)
-            {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
-            }
-
-            if (index > items.Count - count)
-            {
-                ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
-            }
-
-            RemoveItemsRange(index, count);
-        }
-
-        public void ReplaceRange(int index, int count, IEnumerable<T> collection)
-        {
-            if (items.IsReadOnly)
-            {
-                ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_ReadOnlyCollection);
-            }
-
-            if ((uint)index > (uint)items.Count)
-            {
-                ThrowHelper.ThrowArgumentOutOfRange_IndexException();
-            }
-
-            if (count < 0)
-            {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
-            }
-
-            if (index > items.Count - count)
-            {
-                ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
-            }
-
-            if (collection == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.collection);
-            }
-
-            ReplaceItemsRange(index, count, collection);
         }
 
         public void RemoveAt(int index)
@@ -239,42 +162,6 @@ namespace System.Collections.ObjectModel
         protected virtual void SetItem(int index, T item)
         {
             items[index] = item;
-        }
-
-        protected virtual void InsertItemsRange(int index, IEnumerable<T> collection)
-        {
-            if (GetType() == typeof(Collection<T>) && items is List<T> list)
-            {
-                list.InsertRange(index, collection);
-            }
-            else
-            {
-                foreach (T item in collection)
-                {
-                    InsertItem(index++, item);
-                }
-            }
-        }
-
-        protected virtual void RemoveItemsRange(int index, int count)
-        {
-            if (GetType() == typeof(Collection<T>) && items is List<T> list)
-            {
-                list.RemoveRange(index, count);
-            }
-            else
-            {
-                for (int i = 0; i < count; i++)
-                {
-                    RemoveItem(index);
-                }
-            }
-        }
-
-        protected virtual void ReplaceItemsRange(int index, int count, IEnumerable<T> collection)
-        {
-            RemoveItemsRange(index, count);
-            InsertItemsRange(index, collection);
         }
 
         bool ICollection<T>.IsReadOnly

--- a/src/Common/src/CoreLib/System/Memory.cs
+++ b/src/Common/src/CoreLib/System/Memory.cs
@@ -263,41 +263,6 @@ namespace System
         }
 
         /// <summary>
-        /// Forms a slice out of the given memory, beginning at 'startIndex'
-        /// </summary>
-        /// <param name="startIndex">The index at which to begin this slice.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Memory<T> Slice(Index startIndex)
-        {
-            int actualIndex = startIndex.GetOffset(_length);
-            return Slice(actualIndex);
-        }
-
-        /// <summary>
-        /// Forms a slice out of the given memory using the range start and end indexes.
-        /// </summary>
-        /// <param name="range">The range used to slice the memory using its start and end indexes.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Memory<T> Slice(Range range)
-        {
-#if __MonoCS__
-            var offsetAndLength = range.GetOffsetAndLength(_length);
-            int start = offsetAndLength.Offset;
-            int length = offsetAndLength.Length;
-#else
-            (int start, int length) = range.GetOffsetAndLength(_length);
-#endif
-            // It is expected for _index + start to be negative if the memory is already pre-pinned.
-            return new Memory<T>(_object, _index + start, length);
-        }
-
-        /// <summary>
-        /// Forms a slice out of the given memory using the range start and end indexes.
-        /// </summary>
-        /// <param name="range">The range used to slice the memory using its start and end indexes.</param>
-        public Memory<T> this[Range range] => Slice(range);
-
-        /// <summary>
         /// Returns a span from the memory.
         /// </summary>
         public Span<T> Span

--- a/src/Common/src/CoreLib/System/ReadOnlyMemory.cs
+++ b/src/Common/src/CoreLib/System/ReadOnlyMemory.cs
@@ -185,41 +185,6 @@ namespace System
         }
 
         /// <summary>
-        /// Forms a slice out of the given memory, beginning at 'startIndex'
-        /// </summary>
-        /// <param name="startIndex">The index at which to begin this slice.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ReadOnlyMemory<T> Slice(Index startIndex)
-        {
-            int actualIndex = startIndex.GetOffset(_length);
-            return Slice(actualIndex);
-        }
-
-        /// <summary>
-        /// Forms a slice out of the given memory using the range start and end indexes.
-        /// </summary>
-        /// <param name="range">The range used to slice the memory using its start and end indexes.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ReadOnlyMemory<T> Slice(Range range)
-        {
-#if __MonoCS__
-            var offsetAndLength = range.GetOffsetAndLength(_length);
-            int start = offsetAndLength.Offset;
-            int length = offsetAndLength.Length;
-#else
-            (int start, int length) = range.GetOffsetAndLength(_length);
-#endif
-            // It is expected for _index + start to be negative if the memory is already pre-pinned.
-            return new ReadOnlyMemory<T>(_object, _index + start, length);
-        }
-
-        /// <summary>
-        /// Forms a slice out of the given memory using the range start and end indexes.
-        /// </summary>
-        /// <param name="range">The range used to slice the memory using its start and end indexes.</param>
-        public ReadOnlyMemory<T> this[Range range] => Slice(range);
-
-        /// <summary>
         /// Returns a span from the memory.
         /// </summary>
         public ReadOnlySpan<T> Span

--- a/src/Common/src/CoreLib/System/ReadOnlySpan.Fast.cs
+++ b/src/Common/src/CoreLib/System/ReadOnlySpan.Fast.cs
@@ -149,18 +149,6 @@ namespace System
 #endif
         }
 
-        public ref readonly T this[Index index]
-        {
-            get
-            {
-                // Evaluate the actual index first because it helps performance
-                int actualIndex = index.GetOffset(_length);
-                return ref this [actualIndex];
-            }
-        }
-
-        public ReadOnlySpan<T> this[Range range] => Slice(range);
-
         /// <summary>
         /// Returns a reference to the 0th element of the Span. If the Span is empty, returns null reference.
         /// It can be used for pinning and is required to support the use of span within a fixed statement.
@@ -270,39 +258,6 @@ namespace System
             if ((uint)start > (uint)_length || (uint)length > (uint)(_length - start))
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 
-            return new ReadOnlySpan<T>(ref Unsafe.Add(ref _pointer.Value, start), length);
-        }
-
-        /// <summary>
-        /// Forms a slice out of the given read-only span, beginning at 'startIndex'
-        /// </summary>
-        /// <param name="startIndex">The index at which to begin this slice.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ReadOnlySpan<T> Slice(Index startIndex)
-        {
-            int actualIndex;
-            if (startIndex.IsFromEnd)
-                actualIndex = _length - startIndex.Value;
-            else
-                actualIndex = startIndex.Value;
-
-            return Slice(actualIndex);
-        }
-
-        /// <summary>
-        /// Forms a slice out of the given read-only span, beginning at range start index to the range end
-        /// </summary>
-        /// <param name="range">The range which has the start and end indexes used to slice the span.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ReadOnlySpan<T> Slice(Range range)
-        {
-#if __MonoCS__
-            var offsetAndLength = range.GetOffsetAndLength(_length);
-            int start = offsetAndLength.Offset;
-            int length = offsetAndLength.Length;
-#else
-            (int start, int length) = range.GetOffsetAndLength(_length);
-#endif
             return new ReadOnlySpan<T>(ref Unsafe.Add(ref _pointer.Value, start), length);
         }
 

--- a/src/Common/src/CoreLib/System/Span.Fast.cs
+++ b/src/Common/src/CoreLib/System/Span.Fast.cs
@@ -154,18 +154,6 @@ namespace System
 #endif
         }
 
-        public ref T this[Index index]
-        {
-            get
-            {
-                // Evaluate the actual index first because it helps performance
-                int actualIndex = index.GetOffset(_length);
-                return ref this [actualIndex];
-            }
-        }
-
-        public Span<T> this[Range range] => Slice(range);
-
         /// <summary>
         /// Returns a reference to the 0th element of the Span. If the Span is empty, returns null reference.
         /// It can be used for pinning and is required to support the use of span within a fixed statement.
@@ -349,34 +337,6 @@ namespace System
             if ((uint)start > (uint)_length || (uint)length > (uint)(_length - start))
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 
-            return new Span<T>(ref Unsafe.Add(ref _pointer.Value, start), length);
-        }
-
-        /// <summary>
-        /// Forms a slice out of the given span, beginning at 'startIndex'
-        /// </summary>
-        /// <param name="startIndex">The index at which to begin this slice.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Span<T> Slice(Index startIndex)
-        {
-            int actualIndex = startIndex.GetOffset(_length);
-            return Slice(actualIndex);
-        }
-
-        /// <summary>
-        /// Forms a slice out of the given span, beginning at range start index to the range end
-        /// </summary>
-        /// <param name="range">The range which has the start and end indexes used to slice the span.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Span<T> Slice(Range range)
-        {
-#if __MonoCS__
-            var offsetAndLength = range.GetOffsetAndLength(_length);
-            int start = offsetAndLength.Offset;
-            int length = offsetAndLength.Length;
-#else
-            (int start, int length) = range.GetOffsetAndLength(_length);
-#endif
             return new Span<T>(ref Unsafe.Add(ref _pointer.Value, start), length);
         }
 

--- a/src/Common/src/CoreLib/System/String.Manipulation.cs
+++ b/src/Common/src/CoreLib/System/String.Manipulation.cs
@@ -1626,26 +1626,6 @@ namespace System
             return InternalSubString(startIndex, length);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public string Substring(Index startIndex)
-        {
-            int actualIndex = startIndex.GetOffset(Length);
-            return Substring(actualIndex);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public string Substring(Range range)
-        {
-#if __MonoCS__
-            var offsetAndLength = range.GetOffsetAndLength(Length);
-            int start = offsetAndLength.Offset;
-            int length = offsetAndLength.Length;
-#else
-            (int start, int length) = range.GetOffsetAndLength(Length);
-#endif
-            return Substring(start, length);
-        }
-
         private unsafe string InternalSubString(int startIndex, int length)
         {
             Debug.Assert(startIndex >= 0 && startIndex <= this.Length, "StartIndex is out of range!");

--- a/src/Common/src/CoreLib/System/String.cs
+++ b/src/Common/src/CoreLib/System/String.cs
@@ -458,19 +458,6 @@ namespace System
             return (value == null || 0u >= (uint)value.Length) ? true : false;
         }
 
-        [System.Runtime.CompilerServices.IndexerName("Chars")]
-        public char this[Index index]
-        {
-            get
-            {
-                int actualIndex = index.GetOffset(Length);
-                return this[actualIndex];
-            }
-        }
-
-        [System.Runtime.CompilerServices.IndexerName("Chars")]
-        public string this[Range range] => Substring(range);
-
         public static bool IsNullOrWhiteSpace(string value)
         {
             if (value == null) return true;

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BaseNumberConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BaseNumberConverter.cs
@@ -12,6 +12,8 @@ namespace System.ComponentModel
     /// </summary>
     public abstract class BaseNumberConverter : TypeConverter
     {
+        internal BaseNumberConverter() { }
+
         /// <summary>
         /// Determines whether this editor will attempt to convert hex (0x or #) strings
         /// </summary>


### PR DESCRIPTION
These changes were rejected in the upstream
1) Index+Range in Span/Memory: https://github.com/dotnet/standard/commit/77258cd9b6f9275e5d91d21d0a790579be14d1d1 (also, were removed from coreclr)

2) Batch operations in Collection: https://github.com/dotnet/standard/pull/1222 (also being removed in coreclr now)

3) BaseNumberConverter should have internal ctor.