### PR TITLE
[mono-2019-02] Synchronize NS21 changes with upstream

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BaseNumberConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BaseNumberConverter.cs
@@ -12,6 +12,8 @@ namespace System.ComponentModel
     /// </summary>
     public abstract class BaseNumberConverter : TypeConverter
     {
+        internal BaseNumberConverter() { }
+
         /// <summary>
         /// Determines whether this editor will attempt to convert hex (0x or #) strings
         /// </summary>


### PR DESCRIPTION
These changes were rejected in the upstream
1) Index+Range in Span/Memory: https://github.com/dotnet/standard/commit/77258cd9b6f9275e5d91d21d0a790579be14d1d1 (also, were removed from coreclr)

2) Batch operations in Collection: https://github.com/dotnet/standard/pull/1222 (also being removed in coreclr now)

3) BaseNumberConverter should have internal ctor.

Backport of #294.

/cc @marek-safar @EgorBo