### PR TITLE
[mono-2019-02] HttpClient.SendAsync() should not attempt to read response body on a HEAD request.

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -464,7 +464,7 @@ namespace System.Net.Http
                 throw;
             }
 
-            return completionOption == HttpCompletionOption.ResponseContentRead ?
+            return completionOption == HttpCompletionOption.ResponseContentRead && !string.Equals(request.Method.Method, "HEAD", StringComparison.OrdinalIgnoreCase) ?
                 FinishSendAsyncBuffered(sendTask, request, cts, disposeCts) :
                 FinishSendAsyncUnbuffered(sendTask, request, cts, disposeCts);
         }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpRequestMessageTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpRequestMessageTest.cs
@@ -215,6 +215,37 @@ namespace System.Net.Http.Functional.Tests
                 "}", rm.ToString());
         }
 
+        [Fact]
+        public async Task HttpRequest_BodylessMethod_LargeContentLength()
+        {
+            using (HttpClient client = CreateHttpClient())
+            {
+                await LoopbackServer.CreateServerAsync(async (server, uri) =>
+                {
+                    var request = new HttpRequestMessage(HttpMethod.Head, uri);
+
+                    Task<HttpResponseMessage> requestTask = client.SendAsync(request);
+                    
+                    await server.AcceptConnectionAsync(async connection =>
+                    {
+                        // Content-Length greater than 2GB.
+                        string response = LoopbackServer.GetConnectionCloseResponse(
+                            HttpStatusCode.OK, "Content-Length: 2167849215\r\n\r\n");
+                        await connection.SendResponseAsync(response);
+
+                        await requestTask;
+                    });
+
+                    using (HttpResponseMessage result = requestTask.Result)
+                    {
+                        Assert.NotNull(result);
+                        Assert.NotNull(result.Content);
+                        Assert.Equal(2167849215, result.Content.Headers.ContentLength);
+                    }
+                });
+            }
+        }
+
         #region Helper methods
 
         private class MockContent : HttpContent


### PR DESCRIPTION
Backport of https://github.com/dotnet/corefx/pull/38129.

* HttpClient.SendAsync() should not attempt to read response body on a HEAD request.

(cherry picked from commit 73e610f847f9c5100a0cec4a80692969836ff35d)

The description of the upstream PR mentions "HEAD and PUT request" - this was my original approach, which was discussed during code review and then changed into only doing it for HEAD.  Thanks a lot to @kg for pointing this out.

Backport of #297.

/cc @akoeplinger @baulig