### PR TITLE
[mono-2019-02] Remove the newly added test again.

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpRequestMessageTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpRequestMessageTest.cs
@@ -215,37 +215,6 @@ namespace System.Net.Http.Functional.Tests
                 "}", rm.ToString());
         }
 
-        [Fact]
-        public async Task HttpRequest_BodylessMethod_LargeContentLength()
-        {
-            using (HttpClient client = CreateHttpClient())
-            {
-                await LoopbackServer.CreateServerAsync(async (server, uri) =>
-                {
-                    var request = new HttpRequestMessage(HttpMethod.Head, uri);
-
-                    Task<HttpResponseMessage> requestTask = client.SendAsync(request);
-                    
-                    await server.AcceptConnectionAsync(async connection =>
-                    {
-                        // Content-Length greater than 2GB.
-                        string response = LoopbackServer.GetConnectionCloseResponse(
-                            HttpStatusCode.OK, "Content-Length: 2167849215\r\n\r\n");
-                        await connection.SendResponseAsync(response);
-
-                        await requestTask;
-                    });
-
-                    using (HttpResponseMessage result = requestTask.Result)
-                    {
-                        Assert.NotNull(result);
-                        Assert.NotNull(result.Content);
-                        Assert.Equal(2167849215, result.Content.Headers.ContentLength);
-                    }
-                });
-            }
-        }
-
         #region Helper methods
 
         private class MockContent : HttpContent


### PR DESCRIPTION
The test was done against corefx/master and does not compile with our fork because of changes in their `LoopbackServer` as well as a new `HttpClientTestBase` subclass that was introduced in master.

Backport of #300.

/cc @akoeplinger @baulig