### PR TITLE
Marks PropertyInfo as [Serializable]

### DIFF
--- a/src/Common/src/CoreLib/System/Reflection/PropertyInfo.cs
+++ b/src/Common/src/CoreLib/System/Reflection/PropertyInfo.cs
@@ -2,11 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Diagnostics;
 using System.Globalization;
 
 namespace System.Reflection
 {
+    [Serializable]
     public abstract class PropertyInfo : MemberInfo
     {
         protected PropertyInfo() { }


### PR DESCRIPTION
As per https://github.com/mono/mono/issues/14864

Note that this is a Mono CoreFX change only.