### PR TITLE
Fix the issue where SQL connection hangs with zero-connection timeout

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -142,7 +142,7 @@ namespace System.Data.SqlClient.SNI
                 }
                 else
                 {
-                    _socket = Connect(serverName, port, ts);
+                    _socket = Connect(serverName, port, isInfiniteTimeOut ? TimeSpan.FromMilliseconds(Int32.MaxValue) : ts);
                 }
                 
                 if (_socket == null || !_socket.Connected)


### PR DESCRIPTION
Relates to https://github.com/mono/mono/issues/13065.
The fix is suggested in https://github.com/dotnet/SqlClient/issues/58.