### PR TITLE
Add Empty Path Check to the Start of FileSystemWatcher Notify Events

### DIFF
--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
@@ -391,12 +391,38 @@ namespace System.IO
                 throw new ArgumentException(SR.Format(SR.InvalidDirName_NotExists, path), nameof(path));
         }
 
+#if MONO
+        /// <summary>
+        /// Returns true if the path is effectively empty for the current OS.
+        /// This function is borrowed from PathInternal.Windows because Mono
+        /// on the desktop still needs to support the netfx behavior. 
+        /// EffectivelyEmpty means an empty span, null, or just spaces ((char)32).        
+        /// </summary>
+        private bool IsEffectivelyEmpty(ReadOnlySpan<char> path)
+        {
+            if (path.IsEmpty)
+                return true;
+
+            foreach (char c in path)
+            {
+                if (c != ' ')
+                    return false;
+            }
+            return true;
+        }
+#endif
+
         /// <summary>
         /// Sees if the name given matches the name filter we have.
         /// </summary>
         private bool MatchPattern(ReadOnlySpan<char> relativePath)
         {
+#if MONO
+            if (IsEffectivelyEmpty (relativePath))
+                return false;
+#endif
             ReadOnlySpan<char> name = IO.Path.GetFileName(relativePath);
+
             if (name.Length == 0)
                 return false;
 

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
@@ -398,17 +398,9 @@ namespace System.IO
         /// on the desktop still needs to support the netfx behavior. 
         /// EffectivelyEmpty means an empty span, null, or just spaces ((char)32).        
         /// </summary>
-        private bool IsEffectivelyEmpty(ReadOnlySpan<char> path)
+        private static bool IsEffectivelyEmpty(ReadOnlySpan<char> path)
         {
-            if (path.IsEmpty)
-                return true;
-
-            foreach (char c in path)
-            {
-                if (c != ' ')
-                    return false;
-            }
-            return true;
+            return (path.IsEmpty || path.IndexOf(' ') > -1);
         }
 #endif
 

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
@@ -637,5 +637,24 @@ namespace System.IO.Tests
                 }
             }
         }
+
+#if MONO && (!MOBILE || MOBILE_DESKTOP_HOST)
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void FileSystemWatcher_WatchFileWithSpaces()
+        {
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var file = new TempFile(Path.Combine(testDirectory.Path, " ")))
+            using (var watcher = new FileSystemWatcher(testDirectory.Path, "*"))
+            {
+                NotifyFilters filter = NotifyFilters.LastWrite | NotifyFilters.FileName;
+                watcher.NotifyFilter = filter;
+
+                Action action = () => File.AppendAllText(file.Path, "longText!");
+                
+                ExpectNoEvent(watcher, WatcherChangeTypes.Changed, action, expectedPath: file.Path);
+            }
+        }
+#endif
     }
 }


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/15434 by checking if the path is effectively empty before interacting with any Path methods.

We needed to modify the fork at this point because Mono still supports
netfx Path rules, which cannot contain spaces (CoreFX allows this on nix).