### PR TITLE
FileSystem.Unix.cs: use "== null" instead of "is null"

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
@@ -25,7 +25,7 @@ namespace System.IO
             Interop.ErrorInfo errorInfo;
             // get the target of the symlink
             string linkTarget = Interop.Sys.ReadLink(sourceFullPath);
-            if (linkTarget is null)
+            if (linkTarget == null)
             {
                 errorInfo = Interop.Sys.GetLastErrorInfo();
                 throw Interop.GetExceptionForIoErrno(errorInfo, sourceFullPath);


### PR DESCRIPTION
mcs has problems with this new C# feature: "error CS1644: Feature `pattern matching' cannot be used because it is not part of the C# 7.3 language specification"