### PR TITLE
[mono-2019-06] Use the proper method for getting fully resolved temporary file paths

### DIFF
--- a/src/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/System.IO.FileSystem/tests/File/Copy.cs
@@ -60,7 +60,7 @@ namespace System.IO.Tests
             string missing_target = GetTestFilePath();
             string dangling_symlink_new_location = GetTestFilePath();
             Assert.False(File.Exists(missing_target));
-             Assert.Equal(0, symlink(missing_target, dangling_symlink));
+            Assert.Equal(0, symlink(missing_target, dangling_symlink));
             Copy(dangling_symlink, dangling_symlink_new_location);
             Assert.True(File.Exists(dangling_symlink_new_location)); // File.Exists returns true for dangling symlinks
         }

--- a/src/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/System.IO.FileSystem/tests/File/Copy.cs
@@ -60,7 +60,7 @@ namespace System.IO.Tests
             string missing_target = GetTestFilePath();
             string dangling_symlink_new_location = GetTestFilePath();
             Assert.False(File.Exists(missing_target));
-            Assert.Equal(symlink(missing_target, dangling_symlink), 0);
+             Assert.Equal(0, symlink(missing_target, dangling_symlink));
             Copy(dangling_symlink, dangling_symlink_new_location);
             Assert.True(File.Exists(dangling_symlink_new_location)); // File.Exists returns true for dangling symlinks
         }

--- a/src/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/System.IO.FileSystem/tests/File/Copy.cs
@@ -56,9 +56,9 @@ namespace System.IO.Tests
         [PlatformSpecific(TestPlatforms.AnyUnix)]
         public void DanglingSymlinkCopy()
         {
-            string dangling_symlink = GetTestFileName();
-            string missing_target = GetTestFileName();
-            string dangling_symlink_new_location = GetTestFileName();
+            string dangling_symlink = GetTestFilePath();
+            string missing_target = GetTestFilePath();
+            string dangling_symlink_new_location = GetTestFilePath();
             Assert.False(File.Exists(missing_target));
             Assert.Equal(symlink(missing_target, dangling_symlink), 0);
             Copy(dangling_symlink, dangling_symlink_new_location);

--- a/src/System.IO.FileSystem/tests/File/Move.cs
+++ b/src/System.IO.FileSystem/tests/File/Move.cs
@@ -182,9 +182,9 @@ namespace System.IO.Tests
         [PlatformSpecific(TestPlatforms.AnyUnix)]
         public void DanglingSymlinkMove()
         {
-            string dangling_symlink = GetTestFileName();
-            string missing_target = GetTestFileName();
-            string dangling_symlink_new_location = GetTestFileName();
+            string dangling_symlink = GetTestFilePath();
+            string missing_target = GetTestFilePath();
+            string dangling_symlink_new_location = GetTestFilePath();
             Assert.False(File.Exists(missing_target));
             Assert.Equal(symlink(missing_target, dangling_symlink), 0);
             Move(dangling_symlink, dangling_symlink_new_location);

--- a/src/System.IO.FileSystem/tests/File/Move.cs
+++ b/src/System.IO.FileSystem/tests/File/Move.cs
@@ -186,7 +186,7 @@ namespace System.IO.Tests
             string missing_target = GetTestFilePath();
             string dangling_symlink_new_location = GetTestFilePath();
             Assert.False(File.Exists(missing_target));
-             Assert.Equal(0, symlink(missing_target, dangling_symlink));
+            Assert.Equal(0, symlink(missing_target, dangling_symlink));
             Move(dangling_symlink, dangling_symlink_new_location);
             Assert.True(File.Exists(dangling_symlink_new_location)); // File.Exists returns true for dangling symlinks
         }

--- a/src/System.IO.FileSystem/tests/File/Move.cs
+++ b/src/System.IO.FileSystem/tests/File/Move.cs
@@ -186,7 +186,7 @@ namespace System.IO.Tests
             string missing_target = GetTestFilePath();
             string dangling_symlink_new_location = GetTestFilePath();
             Assert.False(File.Exists(missing_target));
-            Assert.Equal(symlink(missing_target, dangling_symlink), 0);
+             Assert.Equal(0, symlink(missing_target, dangling_symlink));
             Move(dangling_symlink, dangling_symlink_new_location);
             Assert.True(File.Exists(dangling_symlink_new_location)); // File.Exists returns true for dangling symlinks
         }


### PR DESCRIPTION
This was a bug in the tests from https://github.com/mono/mono/pull/15616

Backport of #332.

/cc @akoeplinger @alexischr