### PR TITLE
[mono-2019-08] Disable DanglingSymlinkMove/Copy tests on TVOS

### DIFF
--- a/src/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/System.IO.FileSystem/tests/File/Copy.cs
@@ -49,6 +49,7 @@ namespace System.IO.Tests
             Assert.Throws<IOException>(() => Copy(testFile, testFile));
         }
 
+#if !MONOTOUCH_TV // symlink() on a TVOS device always returns EPERM
         [DllImport("libc", SetLastError = true)]
         private static extern int symlink(string target, string linkpath);
 
@@ -64,6 +65,7 @@ namespace System.IO.Tests
             Copy(dangling_symlink, dangling_symlink_new_location);
             Assert.True(File.Exists(dangling_symlink_new_location)); // File.Exists returns true for dangling symlinks
         }
+#endif
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "CoreFX FileStream not yet imported")]

--- a/src/System.IO.FileSystem/tests/File/Move.cs
+++ b/src/System.IO.FileSystem/tests/File/Move.cs
@@ -175,6 +175,7 @@ namespace System.IO.Tests
             Assert.False(File.Exists(testFileSource.FullName));
         }
 
+#if !MONOTOUCH_TV // symlink() on a TVOS device always returns EPERM
         [DllImport("libc", SetLastError = true)]
         private static extern int symlink(string target, string linkpath);
 
@@ -190,6 +191,7 @@ namespace System.IO.Tests
             Move(dangling_symlink, dangling_symlink_new_location);
             Assert.True(File.Exists(dangling_symlink_new_location)); // File.Exists returns true for dangling symlinks
         }
+#endif
 
         [Fact]
         public void FileNameWithSignificantWhitespace()


### PR DESCRIPTION
symlink() doesn't work on TVOS devices.

Backport of #336.

/cc @akoeplinger 