### PR TITLE
Fix issue mono/mono#16435, by improving behavior of FileSystem.Unix File.Move

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
@@ -160,18 +160,18 @@ namespace System.IO
         {
             // The desired behavior for Move(source, dest) is to not overwrite the destination file
             // if it exists. Since rename(source, dest) will replace the file at 'dest' if it exists,
-            // link/unlink are used instead. However, if the source path and the dest path refer to
-            // the same file, then do a rename rather than a link and an unlink.  This is important
-            // for case-insensitive file systems (e.g. renaming a file in a way that just changes casing),
-            // so that we support changing the casing in the naming of the file. If this fails in any
-            // way (e.g. source file doesn't exist, dest file doesn't exist, rename fails, etc.), we
-            // just fall back to trying the link/unlink approach and generating any exceptional messages
-            // from there as necessary.
+            // link/unlink are used instead. Rename is more efficient than link/unlink on file systems
+            // where hard links are not supported (such as FAT). Therefore, given that source file exists,
+            // rename is used in 2 cases: when dest file does not exist or when source path and dest
+            // path refer to the same file (on the same device). This is important for case-insensitive
+            // file systems (e.g. renaming a file in a way that just changes casing), so that we support
+            // changing the casing in the naming of the file. If this fails in any way (e.g. source file
+            // doesn't exist, dest file doesn't exist, rename fails, etc.), we just fall back to trying the
+            // link/unlink approach and generating any exceptional messages from there as necessary.
             Interop.Sys.FileStatus sourceStat, destStat;
             if (Interop.Sys.LStat(sourceFullPath, out sourceStat) == 0 && // source file exists
-                Interop.Sys.LStat(destFullPath, out destStat) == 0 && // dest file exists
-                sourceStat.Dev == destStat.Dev && // source and dest are on the same device
-                sourceStat.Ino == destStat.Ino && // and source and dest are the same file on that device
+               (Interop.Sys.LStat(destFullPath, out destStat) != 0 || // dest file does not exist
+                    sourceStat.Ino == destStat.Ino) && // source and dest are the same file on that device
                 Interop.Sys.Rename(sourceFullPath, destFullPath) == 0) // try the rename
             {
                 // Renamed successfully.


### PR DESCRIPTION
Fix issue https://github.com/mono/mono/issues/16435, by improving behavior of FileSystem.Unix File.Move on file systems that do not support hard links, such as FAT (use rename instead of Copy / Delete)