### PR TITLE
[mono-2019-06] Allow file:// uri's to be provided to HttpClient

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -666,8 +666,12 @@ namespace System.Net.Http
             }
             else
             {
+#if MONO
+                if (!request.RequestUri.IsAbsoluteUri || request.RequestUri.Scheme == Uri.UriSchemeFile && request.RequestUri.OriginalString.StartsWith ("/", StringComparison.Ordinal)))
+#else
                 // If the request Uri is an absolute Uri, just use it. Otherwise try to combine it with the base Uri.
                 if (!request.RequestUri.IsAbsoluteUri)
+#endif
                 {
                     if (_baseAddress == null)
                     {


### PR DESCRIPTION
The Uri will eventually be combined w/ a base address and will eventually make a proper one.

This restores mono's old Uri + HttpClient behavior, added originally by https://github.com/mono/mono/commit/0b7afa989dafd4d712d5a94044fd98ecc40f2ecc

The issue was logged from: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/967582

It appears that the test that would have caught this was disabled via this commit:

https://github.com/mono/mono/commit/2f411750acfd2132f9b4970ef8cf11d9a0f62df9

Backport of #339.

/cc @akoeplinger @steveisok