### PR TITLE
Disable test NetworkStreamTest.ReadAsync_ContinuesOnCurrentSynchronizeContextIfDesired()

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/NetworkStreamTest.netcoreapp.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/NetworkStreamTest.netcoreapp.cs
@@ -215,6 +215,7 @@ namespace System.Net.Sockets.Tests
 
         [Theory]
         [MemberData(nameof(ReadAsync_ContinuesOnCurrentContextIfDesired_MemberData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "Mono does not yet support `continueOnCapturedContext`.")]
         public async Task ReadAsync_ContinuesOnCurrentSynchronizationContextIfDesired(
             bool flowExecutionContext, bool? continueOnCapturedContext)
         {


### PR DESCRIPTION
Disable test NetworkStreamTest.ReadAsync_ContinuesOnCurrentSynchronizeContextIfDesired().

We currently do not run any of the NetworkStream tests; disabling this one will allow us
to do so with my upcoming PR that will use NetworkStream from CoreFX.