### PR TITLE
Enable Color TypeConverter on mobile profiles

### DIFF
--- a/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -24,7 +24,9 @@ namespace System.Drawing
 #endif
 #if FEATURE_TYPECONVERTER
     [TypeConverter(typeof(ColorConverter))]
+#if !MOBILE && !XAMMAC_4_5
     [Editor ("System.Drawing.Design.ColorEditor, " + Consts.AssemblySystem_Drawing_Design, typeof (System.Drawing.Design.UITypeEditor))]
+#endif
 #endif
     public readonly struct Color : IEquatable<Color>
     {


### PR DESCRIPTION
We need to ifdef out the `Editor` attribute since System.Drawing.Design is not there on mobile.