### PR TITLE
Fix System.MissingMemberException

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
@@ -52,7 +52,7 @@ namespace System.Net.Sockets
         internal Task<Socket> AcceptAsync(Socket acceptSocket)
         {
             // Get any cached SocketAsyncEventArg we may have.
-            TaskSocketAsyncEventArgs<Socket> saea = Interlocked.Exchange(ref LazyInitializer.EnsureInitialized(ref _cachedTaskEventArgs).TaskAccept, s_rentedSocketSentinel);
+            TaskSocketAsyncEventArgs<Socket> saea = Interlocked.Exchange(ref LazyInitializer.EnsureInitialized(ref _cachedTaskEventArgs, () => { return new CachedEventArgs(); }).TaskAccept, s_rentedSocketSentinel);
             if (saea == s_rentedSocketSentinel)
             {
                 // An instance was once created (or is currently being created elsewhere), but some other
@@ -194,7 +194,7 @@ namespace System.Net.Sockets
                 return new ValueTask<int>(Task.FromCanceled<int>(cancellationToken));
             }
 
-            AwaitableSocketAsyncEventArgs saea = LazyInitializer.EnsureInitialized(ref LazyInitializer.EnsureInitialized(ref _cachedTaskEventArgs).ValueTaskReceive);
+            AwaitableSocketAsyncEventArgs saea = LazyInitializer.EnsureInitialized(ref LazyInitializer.EnsureInitialized(ref _cachedTaskEventArgs, () => { return new CachedEventArgs(); } ).ValueTaskSend, () => { return new AwaitableSocketAsyncEventArgs(); });
             if (saea.Reserve())
             {
                 Debug.Assert(saea.BufferList == null);
@@ -343,7 +343,7 @@ namespace System.Net.Sockets
                 return new ValueTask<int>(Task.FromCanceled<int>(cancellationToken));
             }
 
-            AwaitableSocketAsyncEventArgs saea = LazyInitializer.EnsureInitialized(ref LazyInitializer.EnsureInitialized(ref _cachedTaskEventArgs).ValueTaskSend);
+            AwaitableSocketAsyncEventArgs saea = LazyInitializer.EnsureInitialized(ref LazyInitializer.EnsureInitialized(ref _cachedTaskEventArgs, () => { return new CachedEventArgs(); } ).ValueTaskSend, () => { return new AwaitableSocketAsyncEventArgs(); });
             if (saea.Reserve())
             {
                 Debug.Assert(saea.BufferList == null);
@@ -367,7 +367,7 @@ namespace System.Net.Sockets
                 return new ValueTask(Task.FromCanceled(cancellationToken));
             }
 
-            AwaitableSocketAsyncEventArgs saea = LazyInitializer.EnsureInitialized(ref LazyInitializer.EnsureInitialized(ref _cachedTaskEventArgs).ValueTaskSend);
+            AwaitableSocketAsyncEventArgs saea = LazyInitializer.EnsureInitialized(ref LazyInitializer.EnsureInitialized(ref _cachedTaskEventArgs, () => { return new CachedEventArgs(); } ).ValueTaskSend, () => { return new AwaitableSocketAsyncEventArgs(); });
             if (saea.Reserve())
             {
                 Debug.Assert(saea.BufferList == null);
@@ -644,7 +644,7 @@ namespace System.Net.Sockets
         private Int32TaskSocketAsyncEventArgs RentSocketAsyncEventArgs(bool isReceive)
         {
             // Get any cached SocketAsyncEventArg we may have.
-            CachedEventArgs cea = LazyInitializer.EnsureInitialized(ref _cachedTaskEventArgs);
+            CachedEventArgs cea = LazyInitializer.EnsureInitialized(ref _cachedTaskEventArgs, () => { return new CachedEventArgs(); });
             Int32TaskSocketAsyncEventArgs saea = isReceive ?
                 Interlocked.Exchange(ref cea.TaskReceive, s_rentedInt32Sentinel) :
                 Interlocked.Exchange(ref cea.TaskSend, s_rentedInt32Sentinel);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
@@ -194,7 +194,7 @@ namespace System.Net.Sockets
                 return new ValueTask<int>(Task.FromCanceled<int>(cancellationToken));
             }
 
-            AwaitableSocketAsyncEventArgs saea = LazyInitializer.EnsureInitialized(ref LazyInitializer.EnsureInitialized(ref _cachedTaskEventArgs, () => { return new CachedEventArgs(); } ).ValueTaskSend, () => { return new AwaitableSocketAsyncEventArgs(); });
+            AwaitableSocketAsyncEventArgs saea = LazyInitializer.EnsureInitialized(ref LazyInitializer.EnsureInitialized(ref _cachedTaskEventArgs, () => { return new CachedEventArgs(); } ).ValueTaskReceive, () => { return new AwaitableSocketAsyncEventArgs(); });
             if (saea.Reserve())
             {
                 Debug.Assert(saea.BufferList == null);


### PR DESCRIPTION
Fixing unit test error of xamarin-macios during mono 2019-10 integration
Error:
System.MissingMemberException : The lazily-initialized type does not have a public, parameterless constructor.
Marek suggested to use a factory lambda when calling LazyInitializer.EnsureInitialized.