### PR TITLE
Clean up some tests and move to new Azure endpoint (#41603)

### DIFF
--- a/src/Common/tests/System/Net/Configuration.Http.cs
+++ b/src/Common/tests/System/Net/Configuration.Http.cs
@@ -8,7 +8,7 @@ namespace System.Net.Test.Common
     {
         public static partial class Http
         {
-            private static readonly string DefaultAzureServer = "corefx-net.cloudapp.net";
+            private static readonly string DefaultAzureServer = "corefx-net-http11.azurewebsites.net";
 
             public static string Host => GetValue("COREFX_HTTPHOST", DefaultAzureServer);
 

--- a/src/Common/tests/System/Net/Configuration.Security.cs
+++ b/src/Common/tests/System/Net/Configuration.Security.cs
@@ -8,7 +8,7 @@ namespace System.Net.Test.Common
     {
         public static partial class Security
         {
-            private static readonly string DefaultAzureServer = "corefx-net.cloudapp.net";
+            private static readonly string DefaultAzureServer = "corefx-net-http11.azurewebsites.net";
 
             public static string ActiveDirectoryName => GetValue("COREFX_NET_AD_DOMAINNAME");
 

--- a/src/Common/tests/System/Net/Configuration.cs
+++ b/src/Common/tests/System/Net/Configuration.cs
@@ -7,7 +7,7 @@ namespace System.Net.Test.Common
     public static partial class Configuration
     {
         #pragma warning disable 414
-        private static readonly string DefaultAzureServer = "corefx-net.cloudapp.net";
+        private static readonly string DefaultAzureServer = "corefx-net-http11.azurewebsites.net";
         #pragma warning restore 414
 
         private static string GetValue(string envName, string defaultValue=null)

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -311,6 +311,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(41108)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "UAP doesn't allow revocation checking to be turned off")]
         [OuterLoop] // TODO: Issue #11345
         [ConditionalFact(nameof(ClientSupportsDHECipherSuites), nameof(BackendSupportsX509Chain))]

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -2701,17 +2701,16 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(HttpStatusCode.MethodNotAllowed, "")]
         public async Task GetAsync_CallMethod_ExpectedStatusLine(HttpStatusCode statusCode, string reasonPhrase)
         {
-            using (HttpClient client = CreateHttpClient())
+            await LoopbackServer.CreateClientAndServerAsync(async uri =>
             {
-                using (HttpResponseMessage response = await client.GetAsync(Configuration.Http.StatusCodeUri(
-                    false,
-                    (int)statusCode,
-                    reasonPhrase)))
+                using (HttpClient client = CreateHttpClient())
+                using (HttpResponseMessage response = await client.GetAsync(uri))
                 {
                     Assert.Equal(statusCode, response.StatusCode);
                     Assert.Equal(reasonPhrase, response.ReasonPhrase);
                 }
-            }
+            }, server => server.AcceptConnectionSendCustomResponseAndCloseAsync(
+                $"HTTP/1.1 {(int)statusCode} {reasonPhrase}\r\nContent-Length: 0\r\n\r\n"));
         }
 
         #endregion

--- a/src/System.Net.WebClient/tests/WebClientTest.cs
+++ b/src/System.Net.WebClient/tests/WebClientTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
@@ -15,6 +16,8 @@ using Xunit;
 
 namespace System.Net.Tests
 {
+    using Configuration = System.Net.Test.Common.Configuration;
+
     public class WebClientTest
     {
         [Fact]
@@ -393,21 +396,26 @@ namespace System.Net.Tests
             await Assert.ThrowsAsync<WebException>(() => wc.DownloadStringTaskAsync(System.Net.Test.Common.Configuration.Http.RemoteEchoServer));
         }
 
-        [OuterLoop("Networking test talking to remote server: issue #11345")]
+        public static IEnumerable<object[]> RequestHeaders_AddHostHeaderAndSendRequest_ExpectedResult_MemberData()
+        {
+            yield return new object[] { $"http://{Configuration.Http.Host}", true };
+            yield return new object[] { Configuration.Http.Host, false };
+        }
+
+        [OuterLoop("Uses external servers")]
         [Theory]
-        [InlineData("http://localhost", true)]
-        [InlineData("localhost", false)]
+        [MemberData(nameof(RequestHeaders_AddHostHeaderAndSendRequest_ExpectedResult_MemberData))]
         public static async Task RequestHeaders_AddHostHeaderAndSendRequest_ExpectedResult(string hostHeaderValue, bool throwsWebException)
         {
             var wc = new WebClient();
             wc.Headers["Host"] = hostHeaderValue;
             if (throwsWebException)
             {
-                await Assert.ThrowsAsync<WebException>(() => wc.DownloadStringTaskAsync(System.Net.Test.Common.Configuration.Http.RemoteEchoServer));
+                await Assert.ThrowsAsync<WebException>(() => wc.DownloadStringTaskAsync(Configuration.Http.RemoteEchoServer));
             }
             else
             {
-                await wc.DownloadStringTaskAsync(System.Net.Test.Common.Configuration.Http.RemoteEchoServer);
+                await wc.DownloadStringTaskAsync(Configuration.Http.RemoteEchoServer);
             }
         }
 

--- a/src/System.Net.WebSockets.Client/tests/CloseTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/CloseTest.cs
@@ -17,6 +17,7 @@ namespace System.Net.WebSockets.Client.Tests
     {
         public CloseTest(ITestOutputHelper output) : base(output) { }
 
+        [ActiveIssue(36016)]
         [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseAsync_ServerInitiatedClose_Success(Uri server)
@@ -194,6 +195,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
+        [ActiveIssue(36016)]
         [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseOutputAsync_ServerInitiated_CanSend(Uri server)

--- a/src/System.Net.WebSockets.Client/tests/ConnectTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/ConnectTest.cs
@@ -92,9 +92,9 @@ namespace System.Net.WebSockets.Client.Tests
         {
             Uri server = System.Net.Test.Common.Configuration.WebSockets.RemoteEchoServer;
 
-            // Send via the physical address such as "corefx-net.cloudapp.net"
-            // Set the Host header to logical address like "subdomain.corefx-net.cloudapp.net"
-            // Verify the scenario works and the remote server received "Host: subdomain.corefx-net.cloudapp.net"
+            // Send via the physical address such as "corefx-net-http11.azurewebsites.net"
+            // Set the Host header to logical address like "subdomain.corefx-net-http11.azurewebsites.net"
+            // Verify the scenario works and the remote server received "Host: subdomain.corefx-net-http11.azurewebsites.net"
             string logicalHost = "subdomain." + server.Host;
 
             using (var cws = new ClientWebSocket())


### PR DESCRIPTION
* Test only fixes *

Port PR #36018 from master branch

This PR changes the Azure test endpoint to use Azure App Service instead of the classic Azure
Cloud Service endpoint. The use of the classic Azure Cloud Service is no longer recommended
since it is harder to maintain.

Once all remaining branches are converted, we will shut down the corefx-net.cloudapp.net
endpoint.

This PR also includes some other test fixes and tests disabled due to active issues.