### PR TITLE
[mono] fixup for c44efe7297f8e11cab157c7e96b998dc936d53b7

### DIFF
--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Scheduling/Scheduling.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Scheduling/Scheduling.cs
@@ -31,9 +31,15 @@ namespace System.Linq.Parallel
         // Whether to preserve order by default, when neither AsOrdered nor AsUnordered is used.
         internal const bool DefaultPreserveOrder = false;
 
+#if MONO
+        // By default limit to degree of 16 to avoid too much contention. It's
+        // still possible to override that to a maximum of MAX_SUPPORTED_DOP.
+        internal static int DefaultDegreeOfParallelism = Math.Min(Environment.ProcessorCount, 16);
+#else
         // The default degree of parallelism, or -1 if unspecified. Dev unit tests set this value
         // to change the default DOP.
         internal static int DefaultDegreeOfParallelism = Math.Min(Environment.ProcessorCount, MAX_SUPPORTED_DOP);
+#endif
 
         // The size to use for bounded buffers. 
         internal const int DEFAULT_BOUNDED_BUFFER_CAPACITY = 512;
@@ -47,13 +53,8 @@ namespace System.Linq.Parallel
         // The number of milliseconds before we assume a producer has been zombied.
         internal const int ZOMBIED_PRODUCER_TIMEOUT = Timeout.Infinite;
 
-#if MONO
-        /* limit to degree of 16 to avoid too much contention */
-        internal const int MAX_SUPPORTED_DOP = 16;
-#else
         // The largest number of partitions that PLINQ supports.
         internal const int MAX_SUPPORTED_DOP = 512;
-#endif
 
 
         //-----------------------------------------------------------------------------------


### PR DESCRIPTION
We only want to change the maximum for the _default_ DOP, but the accepted maximum DOP should remain 512.