### PR TITLE
Update System.Net.Http.Tests.HttpContentTest.Dispose_BufferContentThenDisposeContent_BufferedStreamGetsDisposed

### DIFF
--- a/src/System.Net.Http/tests/UnitTests/HttpContentTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpContentTest.cs
@@ -12,10 +12,10 @@ namespace System.Net.Http.Tests
     public class HttpContentTest
     {
         [Fact]
-        public void Dispose_BufferContentThenDisposeContent_BufferedStreamGetsDisposed()
+        public async Task Dispose_BufferContentThenDisposeContent_BufferedStreamGetsDisposed()
         {
             MockContent content = new MockContent();
-            content.LoadIntoBufferAsync().Wait();
+            await content.LoadIntoBufferAsync();
 
             Type type = typeof(HttpContent);
             TypeInfo typeInfo = type.GetTypeInfo();


### PR DESCRIPTION
It should fix  https://github.com/mono/mono/blob/master/sdks/wasm/xunit-exclusions.rsp#L99:
```
# System.Net.Http.UnitTests
# Hangs
-nomethod System.Net.Http.Tests.HttpContentTest.Dispose_BufferContentThenDisposeContent_BufferedStreamGetsDisposed
```
Related dotnet/runtime test: https://github.com/dotnet/runtime/blob/4f9ae42d861fcb4be2fcd5d3d55d5f227d30e723/src/libraries/System.Net.Http/tests/UnitTests/HttpContentTest.cs#L15

/cc @steveisok 