### PR TITLE
Invalidate DirectoryInfo After Create

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
@@ -82,7 +82,11 @@ namespace System.IO
             throw new ArgumentException(SR.Format(SR.Argument_InvalidSubPath, path, FullPath), nameof(path));
         }
 
-        public void Create() => FileSystem.CreateDirectory(FullPath);
+        public void Create()
+        {
+            FileSystem.CreateDirectory(FullPath);
+            Invalidate();
+        }
 
         // Returns an array of Files in the DirectoryInfo specified by path
         public FileInfo[] GetFiles() => GetFiles("*", enumerationOptions: EnumerationOptions.Compatible);

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Create.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Create.cs
@@ -74,5 +74,14 @@ namespace System.IO.Tests
             DirectoryInfo testInfo = new DirectoryInfo(testDir + extension + trailing);
             Assert.Equal(trailing, testInfo.Extension);
         }
+
+        [Fact]
+        public void CreateDirectoryWithAttributes()
+        {
+            string testDir = Path.Combine(GetTestFilePath(), "CreateDirectoryWithAttributes");
+            DirectoryInfo testInfo = new DirectoryInfo(testDir);
+            testInfo.Create();
+            testInfo.Attributes = FileAttributes.Directory | FileAttributes.Normal;
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/18291

Backport of https://github.com/dotnet/runtime/commit/db671a853e3c7a3eea5016b2dedf7b1977a17002