### PR TITLE
Disable two tests that allocate a lot of memory

### DIFF
--- a/src/System.Collections.NonGeneric/tests/HashtableTests.cs
+++ b/src/System.Collections.NonGeneric/tests/HashtableTests.cs
@@ -234,6 +234,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "Flaky test - OOM")]
         public void Ctor_Int_Int_GenerateNewPrime()
         {
             // The ctor for Hashtable performs the following calculation:

--- a/src/System.Runtime.Extensions/tests/System/BitConverter.cs
+++ b/src/System.Runtime.Extensions/tests/System/BitConverter.cs
@@ -226,6 +226,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "Flaky test - OOM")]
         public static void ToString_ByteArrayTooLong_Throws()
         {
             byte[] arr;


### PR DESCRIPTION
HashTableTests.Ctor_Int_Int_GenerateNewPrime and BitConverterTests.ToString_ByteArrayTooLong_Throws

Causes issues on Windows 32bit and other platforms.