### PR TITLE
[mono-2019-12] FileSystem.Unix.File.Move uses "rename" in more cases (#40611)

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Move.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Move.cs
@@ -22,7 +22,7 @@ namespace System.IO.Tests
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Expected WatcherChangeTypes are different based on OS
         public void Unix_File_Move_To_Same_Directory()
         {
-            FileMove_SameDirectory(WatcherChangeTypes.Created | WatcherChangeTypes.Deleted);
+            FileMove_SameDirectory(WatcherChangeTypes.Renamed);
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace System.IO.Tests
         [PlatformSpecific(TestPlatforms.OSX)]  // Expected WatcherChangeTypes are different based on OS
         public void OSX_File_Move_To_Different_Watched_Directory()
         {
-            FileMove_DifferentWatchedDirectory(WatcherChangeTypes.Changed);
+            FileMove_DifferentWatchedDirectory(0);
         }
 
         [Fact]
@@ -104,7 +104,7 @@ namespace System.IO.Tests
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Expected WatcherChangeTypes are different based on OS
         public void Unix_File_Move_In_Nested_Directory(bool includeSubdirectories)
         {
-            FileMove_NestedDirectory(includeSubdirectories ? WatcherChangeTypes.Created | WatcherChangeTypes.Deleted : 0, includeSubdirectories);
+            FileMove_NestedDirectory(includeSubdirectories ? WatcherChangeTypes.Renamed : 0, includeSubdirectories);
         }
 
         [Fact]
@@ -118,7 +118,7 @@ namespace System.IO.Tests
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Expected WatcherChangeTypes are different based on OS
         public void Unix_File_Move_With_Set_NotifyFilter()
         {
-            FileMove_WithNotifyFilter(WatcherChangeTypes.Deleted);
+            FileMove_WithNotifyFilter(WatcherChangeTypes.Renamed);
         }
 
         #region Test Helpers

--- a/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
@@ -170,8 +170,9 @@ namespace System.IO
             // link/unlink approach and generating any exceptional messages from there as necessary.
             Interop.Sys.FileStatus sourceStat, destStat;
             if (Interop.Sys.LStat(sourceFullPath, out sourceStat) == 0 && // source file exists
-               (Interop.Sys.LStat(destFullPath, out destStat) != 0 || // dest file does not exist
-                    sourceStat.Ino == destStat.Ino) && // source and dest are the same file on that device
+                (Interop.Sys.LStat(destFullPath, out destStat) != 0 || // dest file does not exist
+                (sourceStat.Dev == destStat.Dev && // source and dest are on the same device
+                sourceStat.Ino == destStat.Ino)) && // source and dest are the same file on that device
                 Interop.Sys.Rename(sourceFullPath, destFullPath) == 0) // try the rename
             {
                 // Renamed successfully.

--- a/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
@@ -160,18 +160,18 @@ namespace System.IO
         {
             // The desired behavior for Move(source, dest) is to not overwrite the destination file
             // if it exists. Since rename(source, dest) will replace the file at 'dest' if it exists,
-            // link/unlink are used instead. However, if the source path and the dest path refer to
-            // the same file, then do a rename rather than a link and an unlink.  This is important
-            // for case-insensitive file systems (e.g. renaming a file in a way that just changes casing),
-            // so that we support changing the casing in the naming of the file. If this fails in any
-            // way (e.g. source file doesn't exist, dest file doesn't exist, rename fails, etc.), we
-            // just fall back to trying the link/unlink approach and generating any exceptional messages
-            // from there as necessary.
+            // link/unlink are used instead. Rename is more efficient than link/unlink on file systems
+            // where hard links are not supported (such as FAT). Therefore, given that source file exists,
+            // rename is used in 2 cases: when dest file does not exist or when source path and dest
+            // path refer to the same file (on the same device). This is important for case-insensitive
+            // file systems (e.g. renaming a file in a way that just changes casing), so that we support
+            // changing the casing in the naming of the file. If this fails in any way (e.g. source file
+            // doesn't exist, dest file doesn't exist, rename fails, etc.), we just fall back to trying the
+            // link/unlink approach and generating any exceptional messages from there as necessary.
             Interop.Sys.FileStatus sourceStat, destStat;
             if (Interop.Sys.LStat(sourceFullPath, out sourceStat) == 0 && // source file exists
-                Interop.Sys.LStat(destFullPath, out destStat) == 0 && // dest file exists
-                sourceStat.Dev == destStat.Dev && // source and dest are on the same device
-                sourceStat.Ino == destStat.Ino && // and source and dest are the same file on that device
+               (Interop.Sys.LStat(destFullPath, out destStat) != 0 || // dest file does not exist
+                    sourceStat.Ino == destStat.Ino) && // source and dest are the same file on that device
                 Interop.Sys.Rename(sourceFullPath, destFullPath) == 0) // try the rename
             {
                 // Renamed successfully.


### PR DESCRIPTION
### Cherry-picked commit message
```
* FileSystem.Unix.File.Move use rename in more cases, avoid link/copy when possible, improve performance on file systems that do not support hard links, such as FAT

* Adapt Unit Tests for accounting FileSystemWatcher events fired by FileSystem.Unix.File.Move implementation that use rename in more cases, avoiding link/copy when possible
```
This PR looks to fix the  MonoDevelop.Projects.DotNetCoreFileWatcherTests.AddRenameRemoveSingleFile error described in DevDiv workitem 1089785.
A FileSystemWatcher regression occurred when bots were upgraded from Mojave to Catalina. 
It turns out that File Renamed events were not being sent on Catalina though the files were being properly renamed. 
To fix, a cherry-pick of a commit on `dotnet/corefx` was applied.

### Testing:
Reproduced using desktop mono (6.13.0) on macOS Catalina 10.15.3 using the sample code provided, which was uploaded here https://gist.github.com/mdh1418/f2a47838fbd9b53efa53fe18789a5ebb
```
Mitchells-MacBook-Pro-2:mono mdhwang$ runtime/_tmpinst/bin/csc Hello.cs; mono/mini/mono Hello.exe
Microsoft (R) Visual C# Compiler version 3.5.0-beta4-20153-05 (20b9af91)
Copyright (C) Microsoft Corporation. All rights reserved.
Watching files...
Press a key to quit.
FileChanged: /Users/mdhwang/mono/NewFile0.txt
FileCreated: /Users/mdhwang/mono/NewFile0.txt
FileDeleted: /Users/mdhwang/mono/NewFile0.txt
FileChanged: /Users/mdhwang/mono/NewFile1.txt
FileCreated: /Users/mdhwang/mono/NewFile1.txt
FileDeleted: /Users/mdhwang/mono/NewFile1.txt
FileChanged: /Users/mdhwang/mono/NewFile1.txt
FileCreated: /Users/mdhwang/mono/NewFile1.txt
FileChanged: /Users/mdhwang/mono/NewFile2.txt
FileCreated: /Users/mdhwang/mono/NewFile2.txt
FileChanged: /Users/mdhwang/mono/NewFile2.txt
FileCreated: /Users/mdhwang/mono/NewFile2.txt
FileDeleted: /Users/mdhwang/mono/NewFile2.txt
FileChanged: /Users/mdhwang/mono/NewFile3.txt
FileChanged: /Users/mdhwang/mono/NewFile3.txt
FileDeleted: /Users/mdhwang/mono/NewFile3.txt
```

### Fixing:
Applied the changes to `FileSystem.Unix.cs` to `mono/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs`, ran `make -j` and re-ran the sample program.
```
lo.exe
Microsoft (R) Visual C# Compiler version 3.5.0-beta4-20153-05 (20b9af91)
Copyright (C) Microsoft Corporation. All rights reserved.

Watching files...
Press a key to quit.
FileChanged: /Users/mdhwang/mono/NewFile0.txt
FileCreated: /Users/mdhwang/mono/NewFile0.txt
FileChanged: /Users/mdhwang/mono/NewFile0.txt
FileCreated: /Users/mdhwang/mono/NewFile0.txt
FileRenamed: /Users/mdhwang/mono/NewFile0.txt -> /Users/mdhwang/mono/RenamedFile0.txt
FileChanged: /Users/mdhwang/mono/NewFile1.txt
FileCreated: /Users/mdhwang/mono/NewFile1.txt
FileChanged: /Users/mdhwang/mono/NewFile1.txt
FileCreated: /Users/mdhwang/mono/NewFile1.txt
FileRenamed: /Users/mdhwang/mono/NewFile1.txt -> /Users/mdhwang/mono/RenamedFile1.txt
FileChanged: /Users/mdhwang/mono/NewFile2.txt
FileCreated: /Users/mdhwang/mono/NewFile2.txt
FileChanged: /Users/mdhwang/mono/NewFile2.txt
FileRenamed: /Users/mdhwang/mono/NewFile2.txt -> /Users/mdhwang/mono/RenamedFile2.txt
FileCreated: /Users/mdhwang/mono/NewFile2.txt
FileChanged: /Users/mdhwang/mono/NewFile3.txt
FileCreated: /Users/mdhwang/mono/NewFile3.txt
FileRenamed: /Users/mdhwang/mono/NewFile3.txt -> /Users/mdhwang/mono/RenamedFile3.txt
FileChanged: /Users/mdhwang/mono/NewFile3.txt
FileCreated: /Users/mdhwang/mono/NewFile3.txt
```

Port of https://github.com/dotnet/corefx/pull/40611

Backport of #395.

/cc @akoeplinger @mdh1418