### PR TITLE
[System.Native] Exclude ReadDir pinvoke wrappers on Mono; handle EINTR

### DIFF
--- a/src/Common/src/CoreLib/Interop/Unix/System.Native/Interop.ReadDir.cs
+++ b/src/Common/src/CoreLib/Interop/Unix/System.Native/Interop.ReadDir.cs
@@ -53,16 +53,19 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_OpenDir", SetLastError = true)]
-        internal static extern IntPtr OpenDir(string path);
-
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetReadDirRBufferSize", SetLastError = false)]
         internal static extern int GetReadDirRBufferSize();
+
+
+#if !MONO
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_OpenDir", SetLastError = true)]
+        internal static extern IntPtr OpenDir(string path);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReadDirR", SetLastError = false)]
         internal static extern unsafe int ReadDirR(IntPtr dir, byte* buffer, int bufferSize, out DirectoryEntry outputEntry);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CloseDir", SetLastError = true)]
         internal static extern int CloseDir(IntPtr dir);
+#endif
     }
 }

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -455,7 +455,7 @@ int32_t SystemNative_ReadDirR(DIR* dir, uint8_t* buffer, int32_t bufferSize, str
         //  kernel set errno -> failure
         if (errno != 0)
         {
-            assert_err(errno == EBADF, "Invalid directory stream descriptor dir", errno);
+            assert_err(errno == EBADF || errno == EINTR, "Invalid directory stream descriptor dir", errno);
             return errno;
         }
         return -1;


### PR DESCRIPTION
For Mono we must loop in managed when opendir/readdir/closedir return EINTR in
order to handle Thread.Abort.

This is because while a thread abort will break syscalls with EINTR, throwing the
ThreadAbortException will only happen when the pinvoke returns.

(Although opendir/readdir/clsoedir are not documented to return EINTR, they do
so on macOS Big Sur under certain conditions, so we will need to add managed looping)

Related to https://github.com/mono/mono/issues/20799

This is needed by https://github.com/mono/mono/pull/21016